### PR TITLE
Disable Lint/AmbiguousRegexpLiteral cop

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -47,3 +47,5 @@ Lint/AmbiguousOperator:
   Enabled: false
 Lint/NonLocalExitFromIterator:
   Enabled: false
+Lint/AmbiguousRegexpLiteral:
+  Enabled: false


### PR DESCRIPTION
The cop doesn't like this (perfectly reasonable, IMO) construction in
RSpec tests:

```ruby
expect(foo).to match /bar/
```

@rainforestapp/devs 👍/👎❓