### PR TITLE
Disable Lint/NonLocalExitFromIterator cop

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -45,3 +45,5 @@ Style/IndentationWidth:
 # Dumb lint cops
 Lint/AmbiguousOperator:
   Enabled: false
+Lint/NonLocalExitFromIterator:
+  Enabled: false


### PR DESCRIPTION
This cop flags formations like the following:

```ruby
def foo(bar)
  bar.each do |b|
    do_something_with b
    return if is_the_last_one? b
  end
end
```

I've run into it a couple of times, and honestly I don't understand what
errors it's trying to prevent (it's easy to know the difference between
`break` and `return`).

@rainforestapp/devs 👍/👎❓