### PR TITLE
Enable Style/TrailingCommaInLiteral cop

### DIFF
--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -105,6 +105,9 @@ Style/Tab:
   Enabled: true
 Style/VariableName:
   Enabled: true
+Style/TrailingCommaInLiteral:
+  Enabled: true
+  EnforcedStyleForMultiline: consistent_comma
 Metrics/LineLength:
   Enabled: true
   Max: 120


### PR DESCRIPTION
This enforces the Go-style trailing comma:

```ruby
[
  a,
  b,
  c,
]
```

The advantage is that it's easier to add and remove items from the
literal.

@rainforestapp/devs 👍/👎❓