### PR TITLE
Move Lint/Eval to Security/Eval

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rf
   module Stylez
-    VERSION = '0.2.4'
+    VERSION = '0.2.5'
   end
 end

--- a/ruby/rubocop_lint.yml
+++ b/ruby/rubocop_lint.yml
@@ -80,7 +80,7 @@ Lint/EnsureReturn:
   StyleGuide: 'https://github.com/bbatsov/ruby-style-guide#no-return-ensure'
   Enabled: true
 
-Lint/Eval:
+Security/Eval:
   Description: 'The use of eval represents a serious security risk.'
   Enabled: true
 


### PR DESCRIPTION
I'm having the following error when running `bundle exec circlemator style-check`:
```
/home/ubuntu/nafta/vendor/bundle/ruby/2.3.0/gems/rf-stylez-0.2.4/ruby/rubocop_lint.yml: Lint/Eval has the wrong namespace - should be Security
```

This was caused by recent changes on Rubocop: https://github.com/bbatsov/rubocop/pull/3820