### PR TITLE
RF-4000 Enable Style/SignalException cop

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rf
   module Stylez
-    VERSION = '0.2.6'
+    VERSION = '0.2.7'
   end
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -114,6 +114,8 @@ Style/MultilineIfThen:
   Enabled: true
 Style/Semicolon:
   Enabled: true
+Style/SignalException:
+  Enabled: true
 
 Metrics/LineLength:
   Enabled: true


### PR DESCRIPTION
Enables the `Style/SignalException` cop that forces all exceptions to be raised via `raise` instead of `fail`.