### PR TITLE
RF-5192 use gem instead of rake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,8 +25,8 @@ workflows:
       - push_to_rubygems:
           filters:
             branches:
-              only:
-                - master
+              ignore:
+                - /.*/
             tags:
               only:
                 - /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,9 @@ jobs:
             chmod 600 ~/.gem/credentials
       - run:
           name: Release rf-stylez
-          command: rake release
+          command: |
+            gem build rf-stylez
+            gem push rf-stylez-*.gem
 
 workflows:
   version: 2


### PR DESCRIPTION
Rake release failed when trying to push a tag. We'll already have a tag, so no need for that, so I went back to `gem` command. Also fixes filters, as it is an `or` it triggered for master even without the tag. It *should* work this time.