### PR TITLE
RF-7959 Add Style/RegexpLiteral rule

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rf
   module Stylez
-    VERSION = '0.2.8'
+    VERSION = '0.2.9'
   end
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -121,6 +121,8 @@ Style/SignalException:
   Enabled: true
 Style/SymbolProc:
   Enabled: true
+Style/RegexpLiteral:
+  Enabled: true
 
 Metrics/LineLength:
   Enabled: true


### PR DESCRIPTION
to automate comments like...

<img width="701" alt="screen shot 2018-07-13 at 14 31 13" src="https://user-images.githubusercontent.com/4991698/42691712-70e8aed8-86a9-11e8-9892-5a25224b5a0d.png">

... in the future :) 

defaults for this seem good to go:
- EnforcedStyle: slashes 
- AllowInnerSlashes: false (enforce `%r{}`)