### PR TITLE
Warn about global and special variables

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rf
   module Stylez
-    VERSION = '0.2.12'
+    VERSION = '0.2.13'
   end
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -105,6 +105,10 @@ Naming/FileName:
 Naming/MethodName:
   Enabled: true
 
+Style/SpecialGlobalVars:
+  Enabled: true
+Style/GlobalVars:
+  Enabled: true
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always


### PR DESCRIPTION
Our style guides prefers we don't use global variables or special
variables such as $_ / $. / etc.