### PR TITLE
Remove byebug include

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This is a place for style configurations for [Rainforest QA](https://www.rainfor
 - pull latest master
 - run `rake release:source_control_push`
 - CI/CD will take care of releasing rf-stylez to rubygems
+- Update circlemator `bundle update rf-stylez`
 
 ## Adding `rf-stylez` to a new project
 

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rf
   module Stylez
-    VERSION = '0.2.17'
+    VERSION = '0.2.18'
   end
 end

--- a/lib/rubocop/cop/lint/use_positive_int32_validator.rb
+++ b/lib/rubocop/cop/lint/use_positive_int32_validator.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require 'byebug'
-
 module RuboCop
   module Cop
     module Lint


### PR DESCRIPTION
This causes breakage because byebug is only a development dependency and
the `require byebug'` is in non-develop code which doesn't have byebug
as a dependency.