### PR TITLE
Add NoBangStateMachineEvents Cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: ./ruby/rubocop.yml

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rf
   module Stylez
-    VERSION = '0.2.19'
+    VERSION = '0.2.20'
   end
 end

--- a/lib/rubocop/cop/lint/no_bang_state_machine_events.rb
+++ b/lib/rubocop/cop/lint/no_bang_state_machine_events.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # @example
+      #   # bad - will define `!`-ended method that won't raise
+      #   state_machine :state do
+      #     event :started! do
+      #       ...
+      #     end
+      #   end
+      #
+      #   # good
+      #   state_machine :state do
+      #     event :started do
+      #       ...
+      #     end
+      #   end
+      class NoBangStateMachineEvents < Cop
+        MSG = 'Event names ending with a `!` define `!`-ended methods that do not raise'
+
+        def_node_matcher :is_state_machine_event?, '(send nil? :event (sym $_))'
+        def_node_matcher :is_state_machine?, '(block (send nil? :state_machine ...) ...)'
+
+        def on_send(node)
+          return unless (event_name = is_state_machine_event?(node))
+          return unless is_state_machine?(node.parent.parent)
+          return unless event_name.match?(/\w+!$/)
+
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
+++ b/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Lint::NoBangStateMachineEvents do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers event names ending with a !' do
+    expect_offense(<<-RUBY.strip_indent)
+      state_machine :state do
+        event :started! do
+        ^^^^^^^^^^^^^^^ Event names ending with a `!` define `!`-ended methods that do not raise
+          transition :queued => :in_progress
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register event names without a !' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      state_machine :state do
+        event :started do
+          transition :queued => :in_progress
+        end
+      end
+    RUBY
+  end
+
+  it 'does not register call to event outside of state machine' do
+    expect_no_offenses(<<-RUBY.strip_indent)
+      class SomethingElse
+        event :started! do
+          transition :queued => :in_progress
+        end
+      end
+    RUBY
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require_relative '../lib/rubocop/cop/lint/no_http_party'
 require_relative '../lib/rubocop/cop/lint/obscure'
 require_relative '../lib/rubocop/cop/lint/no_grape_api'
 require_relative '../lib/rubocop/cop/lint/use_positive_int32_validator'
+require_relative '../lib/rubocop/cop/lint/no_bang_state_machine_events'
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense


### PR DESCRIPTION
State machine parses symbols that are passed as event names and defines
some methods. For example, given event named `ship` it will define
`ship` that will fail gracefully by returning false and `ship!` that
will raise an error.

Unfortunately, should you decide to pass a symbol that already ends with
a `!` state_machine will only define the graceful method and end it with
a bang. That causes not only confusion, but also bugs and we have a
bunch of occurrences in our codebase hence this cop