### PR TITLE
Add check for raising untyped exceptions

### DIFF
--- a/lib/rf/stylez.rb
+++ b/lib/rf/stylez.rb
@@ -5,6 +5,7 @@ require 'rubocop/cop/lint/no_http_party'
 require 'rubocop/cop/lint/obscure'
 require 'rubocop/cop/lint/no_grape_api'
 require 'rubocop/cop/lint/use_positive_int32_validator'
+require 'rubocop/cop/lint/no_untyped_raise'
 
 module Rf
   module Stylez

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Rf
   module Stylez
-    VERSION = '0.2.19'
+    VERSION = '0.3.0'
   end
 end

--- a/lib/rubocop/cop/lint/no_untyped_raise.rb
+++ b/lib/rubocop/cop/lint/no_untyped_raise.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module RuboCop
+  module Cop
+    module Lint
+      # @example
+      #   # bad
+      #   raise 'foo'
+      #
+      #   # good
+      #   raise ArgumentError, 'foo'
+      #
+      class NoUntypedRaise < Cop
+        MSG = 'Do not raise untyped exceptions'.freeze
+
+        def_node_matcher :is_untyped_raise?, '(send nil? :raise (str ...) ...)'
+
+        def on_send(node)
+          return unless is_untyped_raise?(node)
+          add_offense(node)
+        end
+      end
+    end
+  end
+end

--- a/lib/rubocop/cop/lint/no_untyped_raise.rb
+++ b/lib/rubocop/cop/lint/no_untyped_raise.rb
@@ -11,9 +11,9 @@ module RuboCop
       #   raise ArgumentError, 'foo'
       #
       class NoUntypedRaise < Cop
-        MSG = 'Do not raise untyped exceptions'.freeze
+        MSG = 'Do not raise untyped exceptions, specify the error type so it can be rescued specifically.'
 
-        def_node_matcher :is_untyped_raise?, '(send nil? :raise (str ...) ...)'
+        def_node_matcher :is_untyped_raise?, '(send nil? {:raise :fail} (str ...) ...)'
 
         def on_send(node)
           return unless is_untyped_raise?(node)

--- a/spec/rubocop/cop/lint/no_untyped_raise.rb
+++ b/spec/rubocop/cop/lint/no_untyped_raise.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Lint::NoUntypedRaise do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when untyped raise' do
+    expect_offense(<<-RUBY.strip_indent)
+      def foo
+        raise 'foo'
+        ^^^^^^^^^^^ Do not raise untyped exceptions
+      end
+    RUBY
+  end
+
+  describe 'when raise is typed' do
+    it 'registers no offense' do
+      expect_no_offenses(<<-RUBY.strip_indent)
+        def foo
+          raise ArgumentError, 'foo'
+        end
+      RUBY
+    end
+  end
+end

--- a/spec/rubocop/cop/lint/no_untyped_raise.rb
+++ b/spec/rubocop/cop/lint/no_untyped_raise.rb
@@ -4,22 +4,50 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when untyped raise' do
-    expect_offense(<<-RUBY.strip_indent)
-      def foo
-        raise 'foo'
-        ^^^^^^^^^^^ Do not raise untyped exceptions
+  describe 'untyped' do
+    context 'raise' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          def foo
+            raise 'foo'
+            ^^^^^^^^^^^ Do not raise untyped exceptions, specify the error type so it can be rescued specifically.
+          end
+        RUBY
       end
-    RUBY
+    end
+
+    context 'fail' do
+      it 'registers an offense' do
+        expect_offense(<<-RUBY.strip_indent)
+          def foo
+            fail 'foo'
+            ^^^^^^^^^^ Do not raise untyped exceptions, specify the error type so it can be rescued specifically.
+          end
+        RUBY
+      end
+    end
   end
 
-  describe 'when raise is typed' do
-    it 'registers no offense' do
-      expect_no_offenses(<<-RUBY.strip_indent)
+
+  describe 'typed' do
+    context 'raise' do
+      it 'registers no offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
         def foo
           raise ArgumentError, 'foo'
         end
-      RUBY
+        RUBY
+      end
+    end
+
+    context 'fail' do
+      it 'registers no offense' do
+        expect_no_offenses(<<-RUBY.strip_indent)
+        def foo
+          fail ArgumentError, 'foo'
+        end
+        RUBY
+      end
     end
   end
 end

--- a/spec/rubocop/cop/lint/no_untyped_raise.rb
+++ b/spec/rubocop/cop/lint/no_untyped_raise.rb
@@ -28,7 +28,6 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
     end
   end
 
-
   describe 'typed' do
     context 'raise' do
       it 'registers no offense' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require_relative '../lib/rubocop/cop/lint/no_http_party'
 require_relative '../lib/rubocop/cop/lint/obscure'
 require_relative '../lib/rubocop/cop/lint/no_grape_api'
 require_relative '../lib/rubocop/cop/lint/use_positive_int32_validator'
+require_relative '../lib/rubocop/cop/lint/no_untyped_raise'
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense


### PR DESCRIPTION
This checks for code that throws untyped (or StandardError) exceptions which is generally a bad practice b/c it makes it hard to catch these exceptions without catching all sorts of other things and is generally not very descriptive. 