### PR TITLE
Remove duplicate config for Naming/MethodName

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.2.22'
+    VERSION = '0.2.23'
   end
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -109,8 +109,6 @@ Naming/ConstantName:
   Enabled: true
 Naming/FileName:
   Enabled: true
-Naming/MethodName:
-  Enabled: true
 
 Style/SpecialGlobalVars:
   Enabled: true


### PR DESCRIPTION
Remove the duplicate config for Naming/MethodName to stop the message:
> 102: `Naming/MethodName` is concealed by line 112