### PR TITLE
RF-17561 Add rubocop-rails so we can use the Rails-specific cops

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,23 @@ This is a place for style configurations for [Rainforest QA](https://www.rainfor
 
 ## Adding `rf-stylez` to a new project
 
+### For Ruby projects
 Create a `.rubocop.yml` in the root project directory and paste the following:
 ```yml
 inherit_gem:
   rf-stylez: ruby/rubocop.yml
-Style/HashSyntax:
-  Enabled: true
 ```
 
-To use it install rubocop and rf-stylez locally:
+### For Rails projects
+Create a `.rubocop.yml` in the root project directory and paste the following:
+```yml
+inherit_gem:
+  rf-stylez:
+    - ruby/rubocop.yml
+    - rails/rubocop.yml
+```
+
+To use it you'll need to install rf-stylez locally:
 ```bash
 gem install rf-stylez
 ```

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.4.1'
+    VERSION = '0.5.0'
   end
 end

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,0 +1,1 @@
+require: rubocop-rails

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rubocop', '>= 0.59', '< 0.81'
-  spec.add_runtime_dependency 'rubocop-rails', '~> 2.5', '>= 2.5.0'
+  spec.add_runtime_dependency 'rubocop-rails', '~> 2.5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'rubocop', '>= 0.59', '< 0.81'
+  spec.add_runtime_dependency 'rubocop-rails', '~> 2.5', '>= 2.5.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 13.0'


### PR DESCRIPTION
* I've added it in such a way that it can be enabled for Rails projects without it being forced upon unsuspecting Ruby-only projects (as described in the README changes).
* I haven't actually gone through all the cops yet to decide what should be on/off - I figure it'll be easier to see what the recommendations are and go from there.
* And I decided to bump the version up to 0.5.0 since this is adding a whole new set of cops - I thought that warranted more than a patch increase.