### PR TITLE
Actually make RSpec cops available when doing inherit_gem: rf-stylez

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   style_check:
     docker:
-      - image: rainforestapp/circlemator:latest
+      - image: gcr.io/rf-public-images/circlemator:latest
     steps:
       - checkout
       - run:

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.7.0'
+    VERSION = '0.7.1.pre'
   end
 end

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.7.1.pre'
+    VERSION = '0.7.1'
   end
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -18,6 +18,7 @@ inherit_from:
 
 require:
   - rf/stylez
+  - rubocop-rspec
 
 # Custom cops
 Lint/NoENV:


### PR DESCRIPTION
### TODO pre-merge
- [x] Change version to `0.7.1`.
- [x] Switch circlemator tag back to `latest` (TBD: keep it on gcr.io or switch it back to dockerhub? the former is autoupdated whenever there's a merge to `master`, the latter we haven't touched since February 2019...) This will cause the `style_check` build to fail, but that's OK since it's a non-blocking check.

### TODO post-merge
- [ ] Release `0.7.1` on Rubygems.
- [ ] Update circlemator image.
- [ ] Rebuild `style_check` on `master`. It should now pass.
