### PR TITLE
v0.8.0 release (update rubocop dependencies)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   style_check:
     docker:
-      - image: gcr.io/rf-public-images/circlemator:ef2e92d1d5af84e9a4a7a6150a736ae16693ed27
+      - image: gcr.io/rf-public-images/circlemator:288c760e2e8a8bd43db86c0470c9ee259367cff3
     steps:
       - checkout
       - run:

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.8.0.pre'
+    VERSION = '0.8.0.pre2'
   end
 end

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.8.0.pre2'
+    VERSION = '0.8.0'
   end
 end


### PR DESCRIPTION
Went with a minor rather than patch version update since the Rubocop changes are breaking (some cops were removed).

Changes since 0.7.2: https://github.com/rainforestapp/rf-stylez/compare/v0.7.2..v0.8.0.pre2

Once this is shipped, `circlemator` can be updated and the `style_check` CI job can use the `circlemator:latest` image once more.