### PR TITLE
RF-20100 Lock dependencies

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.9.0'
+    VERSION = '0.10.0'
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = ['rf-stylez']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 0.81', '< 1.2'
-  spec.add_runtime_dependency 'rubocop-rails', '>= 2.5', '< 2.9'
-  spec.add_runtime_dependency 'rubocop-rspec', '>= 1.39', '< 1.45'
+  spec.add_runtime_dependency 'rubocop', '~> 1.1.0'
+  spec.add_runtime_dependency 'rubocop-rails', '2.8.0'
+  spec.add_runtime_dependency 'rubocop-rspec', '2.0.0.pre'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'
   spec.add_runtime_dependency 'semantic_versioning', '~> 0.2'
 


### PR DESCRIPTION
Rf-stylez is our source of truth on Rubocop definitions os, with a more 
   specific dependency definitions it can also become our source of truth on
   what version of rubocop and it's extensions we run