### PR TITLE
Pin specific rubocop version

### DIFF
--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = ['rf-stylez']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '>= 1.1', '< 1.12'
+  spec.add_runtime_dependency 'rubocop', '1.12'
   spec.add_runtime_dependency 'rubocop-rails', '2.9.1'
   spec.add_runtime_dependency 'rubocop-rspec', '2.3.0'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'


### PR DESCRIPTION
In the past we've been adding RF Stylez to our Gemfiles and that's why
we needed the soft dependency.

It's no longer the case so let's pin a specific rubocop version