### PR TITLE
Add NoVCRRecording cop

### DIFF
--- a/lib/rf/stylez.rb
+++ b/lib/rf/stylez.rb
@@ -9,6 +9,7 @@ require 'rubocop/cop/lint/obscure'
 require 'rubocop/cop/lint/no_grape_api'
 require 'rubocop/cop/lint/use_positive_int32_validator'
 require 'rubocop/cop/lint/no_untyped_raise'
+require 'rubocop/cop/lint/no_vcr_recording'
 
 module Rf
   module Stylez

--- a/lib/rubocop/cop/lint/no_vcr_recording.rb
+++ b/lib/rubocop/cop/lint/no_vcr_recording.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+require 'unparser'
+
+module RuboCop
+  module Cop
+    module Lint
+      # @example
+      #   # bad
+      #   vcr: { record_mode: :once, tag: :foo }
+      #   vcr: { record_mode: :none }
+      #
+      #   # good
+      #   vcr: { tag: :foo }
+      #   vcr: true
+      class NoVCRRecording < RuboCop::Cop::Base
+        extend AutoCorrector
+
+        MSG = 'Do not set :record option in VCR'.freeze
+
+        def_node_search :is_only_setting_record_option?, <<~PATTERN
+          (pair
+            (sym :vcr)
+            (hash
+              (pair
+                (sym :record)
+                ...
+              )
+            )
+          )
+        PATTERN
+        def_node_search :is_setting_record_option?, <<~PATTERN
+          (pair
+            (sym :vcr)
+            (hash
+              <
+                (pair
+                  (sym :record)
+                  ...
+                )
+                ...
+              >
+            )
+          )
+        PATTERN
+
+        def on_pair(node)
+          return unless is_only_setting_record_option?(node) || is_setting_record_option?(node)
+
+          add_offense(node) do |corrector|
+            if is_only_setting_record_option?(node)
+              corrector.replace(node, 'vcr: true')
+            elsif is_setting_record_option?(node)
+              corrector.replace(node, remove_record_option(node))
+            end
+          end
+        end
+
+        private
+
+        def remove_record_option(top_pair_node)
+          extend AST::Sexp
+
+          _vcr_key, hash = top_pair_node.children
+          other_options = hash.children.reject do |pair|
+            key, _value = pair.children
+            key == s(:sym, :record)
+          end
+
+          Unparser.unparse(s(:pair, s(:sym, :vcr), s(:hash, *other_options)))
+        end
+      end
+    end
+  end
+end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop-rspec', '2.3.0'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'
   spec.add_runtime_dependency 'semantic_versioning', '~> 0.2'
+  spec.add_runtime_dependency 'unparser', '~> 0.6'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -34,6 +34,10 @@ Lint/UsePositiveInt32Validator:
   Enabled: true
 Lint/NoJSON:
   Enabled: true
+Lint/NoVCRRecording:
+  Enabled: true
+  Include:
+    - spec/**/*
 
 # Good style cops
 Layout/BlockAlignment:

--- a/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
+++ b/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+describe RuboCop::Cop::Lint::NoVCRRecording do
+  let(:config) { RuboCop::Config.new }
+  subject(:cop) { described_class.new(config) }
+
+  it 'registers an offense when using vcr: { record: ... }' do
+    expect_offense(<<~RUBY)
+      describe Foo, vcr: { record: :new_episodes } do
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set :record option in VCR
+        include_examples 'all the networks!'
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      describe Foo, vcr: true do
+        include_examples 'all the networks!'
+      end
+    RUBY
+  end
+
+  it 'handles multiple options passed to vcr' do
+    expect_offense(<<~RUBY)
+      it 'works!', vcr: { tag: :workworkwork, record: :once } do
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set :record option in VCR
+        expect(let_me_google_that_for_you).to be_full_of_sass
+      end
+    RUBY
+
+    expect_correction(<<~RUBY)
+      it 'works!', vcr: { tag: :workworkwork } do
+        expect(let_me_google_that_for_you).to be_full_of_sass
+      end
+    RUBY
+  end
+
+  it 'does not register an offense when not using :record' do
+    expect_no_offenses(<<~RUBY)
+      context 'with no recording', vcr: true do
+        specify { expect(true).to eq(true) }
+      end
+    RUBY
+
+    expect_no_offenses(<<~RUBY)
+      context 'with no recording', vcr: { match_requests_on: [:request, :path] } do
+        specify { expect(false).to eq(false) }
+      end
+    RUBY
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require_relative '../lib/rubocop/cop/lint/no_grape_api'
 require_relative '../lib/rubocop/cop/lint/use_positive_int32_validator'
 require_relative '../lib/rubocop/cop/lint/no_bang_state_machine_events'
 require_relative '../lib/rubocop/cop/lint/no_untyped_raise'
+require_relative '../lib/rubocop/cop/lint/no_vcr_recording'
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense


### PR DESCRIPTION
This way we don't accidentally commit specs which could make network calls on every CI build due to a forgotten `record: :new_episodes`.