### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.11.1'
+    VERSION = '0.12.0'
   end
 end


### PR DESCRIPTION
`style_check` will continue to fail until this release is pushed to RubyGems and the `circlemator` Docker image updated to use it.