### PR TITLE
Enable Style/Documentation to enforce top-level class comments

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.13.0'
+    VERSION = '0.14.0'
   end
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -176,6 +176,10 @@ Style/SymbolProc:
   Enabled: true
 Style/RegexpLiteral:
   Enabled: true
+Style/Documentation:
+  Enabled: true
+Style/DocumentationMethod:
+  Enabled: false
 
 Layout/LineLength:
   Enabled: true

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -186,6 +186,8 @@ Layout/LineLength:
   Max: 120
   AllowHeredoc: true
   AllowURI: true
+Layout/EmptyLineAfterMagicComment:
+  Enabled: true
 
 # Dumb lint cops
 Lint/AmbiguousOperator:


### PR DESCRIPTION
Writing better code comments is something that we brought up recently in misc discussions and the weekly backend meeting. I think enabling [the `Style/Documentation` cop](https://docs.rubocop.org/rubocop/cops_style.html#styledocumentation) could help us do this more as it'll flag at the `class`/`module` keyword unless there's at least one line of comment above. Please share your thoughts in the comments