### PR TITLE
Remove .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: ruby
-rvm:
-  - 2.6.3
-  - 2.5.1
-  - 2.4.4
-before_install: gem install bundler -v 1.10.6


### PR DESCRIPTION
Remove Travis CI as we don't use it and following https://blog.travis-ci.com/2022-04-17-securitybulletin