### PR TITLE
Add .reek.yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org' do
-  # Specify your gem's dependencies in rf-stylez.gemspec
-  gemspec
-end
+source "https://rubygems.org"
+
+gemspec

--- a/bin/rf-stylez
+++ b/bin/rf-stylez
@@ -4,9 +4,12 @@ require "bundler/setup"
 require "rf/stylez"
 
 command = ARGV.first
-unless command == 'check-latest'
-  STDERR.puts('Usage: rf-stylez check-latest')
-  return
+case command
+when 'check-latest'
+  Rf::Stylez::UpdateCheck.check
+when 'reek-config-path'
+  puts(Rf::Stylez.reek_config_path)
+else
+  STDERR.puts('Usage: rf-stylez [check-latest][reek-config-path]')
 end
 
-Rf::Stylez::UpdateCheck.check

--- a/lib/rf/stylez.rb
+++ b/lib/rf/stylez.rb
@@ -13,5 +13,8 @@ require 'rubocop/cop/lint/no_vcr_recording'
 
 module Rf
   module Stylez
+    def self.reek_config_path
+      File.expand_path("../../ruby/.reek.yml", __dir__)
+    end
   end
 end

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.14.0'
+    VERSION = '0.15.0'
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop', '1.15.0'
   spec.add_runtime_dependency 'rubocop-rails', '2.10.1'
   spec.add_runtime_dependency 'rubocop-rspec', '2.3.0'
+  spec.add_runtime_dependency 'reek', '~> 6.1'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'
   spec.add_runtime_dependency 'semantic_versioning', '~> 0.2'
   spec.add_runtime_dependency 'unparser', '~> 0.6'

--- a/ruby/.reek.yml
+++ b/ruby/.reek.yml
@@ -1,5 +1,7 @@
 ---
 ### Generic smell configuration
+
+# You can check all defaults at https://github.com/troessner/reek/blob/master/docs/defaults.reek.yml
 detectors:
   # IrresponsibleModule duplicates rubocop top-level comment rule
   IrresponsibleModule:
@@ -55,4 +57,6 @@ directories:
 
 exclude_paths:
   - db/
+  - script/
+  - bin/
   - app/jobs/data_correction/

--- a/ruby/.reek.yml
+++ b/ruby/.reek.yml
@@ -1,0 +1,58 @@
+---
+### Generic smell configuration
+detectors:
+  # IrresponsibleModule duplicates rubocop top-level comment rule
+  IrresponsibleModule:
+    enabled: false
+
+  NestedIterators:
+    max_allowed_nesting: 1
+
+  UtilityFunction:
+    public_methods_only: true
+
+  TooManyStatements:
+    max_statements: 10
+
+  TooManyMethods:
+    max_methods: 20
+
+  TooManyInstanceVariables:
+    max_instance_variables: 8
+
+### Directory specific configuration
+
+# You can configure smells on a per-directory base.
+# E.g. the classic Rails case: controllers smell of NestedIterators (see /docs/Nested-Iterators.md) and
+# helpers smell of UtilityFunction (see docs/Utility-Function.md)
+#
+# Note that we only allow configuration on a directory level, not a file level,
+# so all paths have to point to directories.
+# A Dir.glob pattern can be used.
+directories:
+  "app/controllers":
+    NestedIterators:
+      max_allowed_nesting: 2
+    UnusedPrivateMethod:
+      enabled: false
+    InstanceVariableAssumption:
+      enabled: false
+  "app/helpers":
+    UtilityFunction:
+      enabled: false
+  "app/mailers":
+    InstanceVariableAssumption:
+      enabled: false
+  "app/models":
+    InstanceVariableAssumption:
+      enabled: false
+  "app/rack/api":
+    MissingSafeMethod:
+      exclude:
+        - validate_param!
+    InstanceVariableAssumption:
+      enabled: false
+
+exclude_paths:
+  - db/
+  - app/jobs/data_correction/


### PR DESCRIPTION
Starter Reek config file ✨ Let's go through _all_ the warnings from [the defaults](https://github.com/troessner/reek/blob/master/docs/defaults.reek.yml) and check what we might want to override here. The YAML I'm committing now is not finalised!

Once it is finalised, we can configure a `pronto-reek` Github Action to comment on our PRs. I believe this would make more sense than blocking on `pre-push`, like we do with Rubocop, because Reek design-oriented warnings may require more effort to fix.

Reek does not support config inheritance, at least until https://github.com/troessner/reek/issues/1512, so I thought we can reuse our config with something like `reek -c $(rf-stylez reek-config-path)` in the pronto action.

Let's discuss!