### PR TITLE
[DNM] Upgrade to support Ruby 3.1.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/ruby:2.7.1
+      - image: cimg/ruby:3.1.3
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -47,7 +47,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: circleci/ruby:2.7.1
+      - image: cimg/ruby:3.1.3
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .byebug_history
+.tool-versions

--- a/lib/rf/stylez/update_check.rb
+++ b/lib/rf/stylez/update_check.rb
@@ -4,8 +4,6 @@ require 'json'
 require 'net/http'
 require 'logger'
 
-require 'semantic_versioning'
-
 module Rf
   module Stylez
     module UpdateCheck
@@ -13,9 +11,9 @@ module Rf
 
       def self.check
         logger = Logger.new(STDOUT)
-        current_version = SemanticVersioning::Version.new(VERSION)
+        current_version = Gem::Version.new(VERSION)
 
-        remote_version = SemanticVersioning::Version.new(
+        remote_version = Gem::Version.new(
           JSON.parse(Net::HTTP.get(RUBYGEMS_URL))['version']
         )
         if current_version >= remote_version

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.15.1'
+    VERSION = '0.16.0'
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'rubocop-rspec', '2.3.0'
   spec.add_runtime_dependency 'reek', '~> 6.1'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'
-  spec.add_runtime_dependency 'semantic_versioning', '~> 0.2'
   spec.add_runtime_dependency 'unparser', '~> 0.6'
 
   spec.add_development_dependency 'bundler', '~> 2.1'

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -19,9 +19,9 @@ Gem::Specification.new do |spec|
   spec.executables   = ['rf-stylez']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '1.15.0'
-  spec.add_runtime_dependency 'rubocop-rails', '2.10.1'
-  spec.add_runtime_dependency 'rubocop-rspec', '2.3.0'
+  spec.add_runtime_dependency 'rubocop', '1.41.1'
+  spec.add_runtime_dependency 'rubocop-rails', '2.17.4'
+  spec.add_runtime_dependency 'rubocop-rspec', '2.16.0'
   spec.add_runtime_dependency 'reek', '~> 6.1'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'
   spec.add_runtime_dependency 'unparser', '~> 0.6'


### PR DESCRIPTION
**NOTES:**
- I had to deprecate `SemanticVersioning` gem dependency which was causing issues and seems no longer maintained. Moreover it seems it was used for something that is included in `Gem` standard lib (https://medium.com/little-programming-joys/how-to-compare-version-strings-in-ruby-ced0916a4b71)
- CI is failing due to `circlemator` not being updated. I have an open PR for that: https://github.com/rainforestapp/circlemator/pull/159 --> EDIT: this PR has been merged but CI is still failing. I had to open a new PRs which hopefully will fix this https://github.com/rainforestapp/circlemator/pull/164.