### PR TITLE
Fix rubocop alerts

### DIFF
--- a/lib/rf/stylez.rb
+++ b/lib/rf/stylez.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'rf/stylez/version'
-require 'rf/stylez/update_check'
-require 'rubocop'
-require 'rubocop/cop/lint/no_json'
-require 'rubocop/cop/lint/no_http_party'
-require 'rubocop/cop/lint/obscure'
-require 'rubocop/cop/lint/no_grape_api'
-require 'rubocop/cop/lint/use_positive_int32_validator'
-require 'rubocop/cop/lint/no_untyped_raise'
-require 'rubocop/cop/lint/no_vcr_recording'
+require "rf/stylez/version"
+require "rf/stylez/update_check"
+require "rubocop"
+require "rubocop/cop/lint/no_json"
+require "rubocop/cop/lint/no_http_party"
+require "rubocop/cop/lint/obscure"
+require "rubocop/cop/lint/no_grape_api"
+require "rubocop/cop/lint/use_positive_int32_validator"
+require "rubocop/cop/lint/no_untyped_raise"
+require "rubocop/cop/lint/no_vcr_recording"
 
 module Rf
   module Stylez

--- a/lib/rf/stylez/update_check.rb
+++ b/lib/rf/stylez/update_check.rb
@@ -1,32 +1,32 @@
 # frozen_string_literal: true
 
-require 'json'
-require 'net/http'
-require 'logger'
+require "json"
+require "net/http"
+require "logger"
 
 module Rf
   module Stylez
     module UpdateCheck
-      RUBYGEMS_URL = URI('https://rubygems.org/api/v1/gems/rf-stylez.json').freeze
+      RUBYGEMS_URL = URI("https://rubygems.org/api/v1/gems/rf-stylez.json").freeze
 
       def self.check
         logger = Logger.new(STDOUT)
         current_version = Gem::Version.new(VERSION)
 
         remote_version = Gem::Version.new(
-          JSON.parse(Net::HTTP.get(RUBYGEMS_URL))['version']
+          JSON.parse(Net::HTTP.get(RUBYGEMS_URL))["version"]
         )
         if current_version >= remote_version
-          logger.info('You are running latest rf-stylez ')
-          logger.info('(•_•) ( •_•)>⌐■-■ (⌐■_■)')
+          logger.info("You are running latest rf-stylez ")
+          logger.info("(•_•) ( •_•)>⌐■-■ (⌐■_■)")
         else
-          logger.warn('RF Stylez is out of date!')
+          logger.warn("RF Stylez is out of date!")
           logger.warn("Newest version is: #{remote_version}")
           logger.warn("You are running: #{current_version}")
-          logger.warn('Please update: `gem update rf-stylez`')
+          logger.warn("Please update: `gem update rf-stylez`")
         end
       rescue SocketError
-        logger.info('Offline, cannot check for rf-stylez updates')
+        logger.info("Offline, cannot check for rf-stylez updates")
       end
     end
   end

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.16.0'
+    VERSION = "0.16.0"
   end
 end

--- a/lib/rubocop/cop/lint/no_bang_state_machine_events.rb
+++ b/lib/rubocop/cop/lint/no_bang_state_machine_events.rb
@@ -18,10 +18,10 @@ module RuboCop
       #     end
       #   end
       class NoBangStateMachineEvents < Cop
-        MSG = 'Event names ending with a `!` define `!`-ended methods that do not raise'
+        MSG = "Event names ending with a `!` define `!`-ended methods that do not raise"
 
-        def_node_matcher :is_state_machine_event?, '(send nil? :event (sym $_))'
-        def_node_matcher :is_state_machine?, '(block (send nil? :state_machine ...) ...)'
+        def_node_matcher :is_state_machine_event?, "(send nil? :event (sym $_))"
+        def_node_matcher :is_state_machine?, "(block (send nil? :state_machine ...) ...)"
 
         def on_send(node)
           return unless (event_name = is_state_machine_event?(node))

--- a/lib/rubocop/cop/lint/no_grape_api.rb
+++ b/lib/rubocop/cop/lint/no_grape_api.rb
@@ -13,9 +13,9 @@ module RuboCop
       #   # good
       #   class Foo < Api::Base
       class NoGrapeAPI < Cop
-        MSG = 'Prefer inheriting `Api::AuthBase` or `Api::Base` instead of `Grape::API`.'.freeze
+        MSG = "Prefer inheriting `Api::AuthBase` or `Api::Base` instead of `Grape::API`."
 
-        def_node_matcher :inherits_Grape_API?, '(class (const ...) (const (const nil? :Grape) :API) ...)'
+        def_node_matcher :inherits_Grape_API?, "(class (const ...) (const (const nil? :Grape) :API) ...)"
 
         def on_class(node)
           return unless inherits_Grape_API?(node)

--- a/lib/rubocop/cop/lint/no_http_party.rb
+++ b/lib/rubocop/cop/lint/no_http_party.rb
@@ -10,9 +10,9 @@ module RuboCop
       #   # good
       #   TimedRequest.get(...)
       class NoHTTParty < Cop
-        MSG = 'Prefer `TimedRequest` instead of raw `HTTParty` calls.'.freeze
+        MSG = "Prefer `TimedRequest` instead of raw `HTTParty` calls."
 
-        def_node_matcher :is_HTTParty?, '(send (const nil? :HTTParty) ...)'
+        def_node_matcher :is_HTTParty?, "(send (const nil? :HTTParty) ...)"
 
         def on_send(node)
           return unless is_HTTParty?(node)

--- a/lib/rubocop/cop/lint/no_json.rb
+++ b/lib/rubocop/cop/lint/no_json.rb
@@ -11,9 +11,9 @@ module RuboCop
       #   MultiJson.load(...)
       #
       class NoJSON < Cop
-        MSG = 'Use `MultiJson` instead of `JSON`.'.freeze
+        MSG = "Use `MultiJson` instead of `JSON`."
 
-        def_node_matcher :is_JSON?, '(const nil? :JSON)'
+        def_node_matcher :is_JSON?, "(const nil? :JSON)"
 
         def on_const(node)
           return unless is_JSON?(node)

--- a/lib/rubocop/cop/lint/no_untyped_raise.rb
+++ b/lib/rubocop/cop/lint/no_untyped_raise.rb
@@ -11,9 +11,9 @@ module RuboCop
       #   raise ArgumentError, 'foo'
       #
       class NoUntypedRaise < Cop
-        MSG = 'Do not raise untyped exceptions, specify the error type so it can be rescued specifically.'
+        MSG = "Do not raise untyped exceptions, specify the error type so it can be rescued specifically."
 
-        def_node_matcher :is_untyped_raise?, '(send nil? {:raise :fail} (str ...) ...)'
+        def_node_matcher :is_untyped_raise?, "(send nil? {:raise :fail} (str ...) ...)"
 
         def on_send(node)
           return unless is_untyped_raise?(node)

--- a/lib/rubocop/cop/lint/no_vcr_recording.rb
+++ b/lib/rubocop/cop/lint/no_vcr_recording.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
-require 'unparser'
+
+require "unparser"
 
 module RuboCop
   module Cop
@@ -15,7 +16,7 @@ module RuboCop
       class NoVCRRecording < RuboCop::Cop::Base
         extend AutoCorrector
 
-        MSG = 'Do not set :record option in VCR'.freeze
+        MSG = "Do not set :record option in VCR"
 
         def_node_search :is_only_setting_record_option?, <<~PATTERN
           (pair
@@ -48,7 +49,7 @@ module RuboCop
 
           add_offense(node) do |corrector|
             if is_only_setting_record_option?(node)
-              corrector.replace(node, 'vcr: true')
+              corrector.replace(node, "vcr: true")
             elsif is_setting_record_option?(node)
               corrector.replace(node, remove_record_option(node))
             end

--- a/lib/rubocop/cop/lint/obscure.rb
+++ b/lib/rubocop/cop/lint/obscure.rb
@@ -20,7 +20,7 @@ module RuboCop
       #
       # https://ruby-doc.org/core-2.4.0/String.html#method-i-25
       class Obscure < Cop
-        MSG = 'Do not use the flipflop operator'.freeze
+        MSG = "Do not use the flipflop operator"
 
         def_node_matcher :is_stringformat?, <<-PATTERN
           (send {str dstr} $:% ...)
@@ -36,7 +36,7 @@ module RuboCop
 
         def on_send(node)
           return unless is_stringformat?(node)
-          add_offense(node, message: 'Do not use String#%')
+          add_offense(node, message: "Do not use String#%")
         end
       end
     end

--- a/lib/rubocop/cop/lint/use_positive_int32_validator.rb
+++ b/lib/rubocop/cop/lint/use_positive_int32_validator.rb
@@ -14,7 +14,7 @@ module RuboCop
       #     requires :id, type: Integer, positive_int32: true
       #   end
       class UsePositiveInt32Validator < Cop
-        MSG = 'If this Integer maps to a postgres Integer column, validate with `positive_int32: true`'
+        MSG = "If this Integer maps to a postgres Integer column, validate with `positive_int32: true`"
 
         # check if the param is `requires` / `optional`
         def_node_search :find_params_hashes, <<~PATTERN
@@ -23,9 +23,9 @@ module RuboCop
           $(hash ...) ...)
         PATTERN
         # check if hash contains `type: Integer`
-        def_node_search :is_type_integer?, '(pair (sym :type) (const nil? :Integer))'
+        def_node_search :is_type_integer?, "(pair (sym :type) (const nil? :Integer))"
         # check if the hash contains the `positive_int32` validator
-        def_node_search :validates_integer?, '(pair (sym :positive_int32) {{true false} (int _)})'
+        def_node_search :validates_integer?, "(pair (sym :positive_int32) {{true false} (int _)})"
 
         def on_block(node)
           return unless (hash = find_params_hashes(node))

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -1,34 +1,36 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'rf/stylez/version'
+require "rf/stylez/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'rf-stylez'
+  spec.name          = "rf-stylez"
   spec.version       = Rf::Stylez::VERSION
-  spec.authors       = ['Emanuel Evans']
-  spec.email         = ['emanuel@rainforestqa.com']
-  spec.license       = 'MIT'
+  spec.authors       = ["Emanuel Evans"]
+  spec.email         = ["emanuel@rainforestqa.com"]
+  spec.license       = "MIT"
 
   spec.summary       = %q{Styles for Rainforest code}
-  spec.description   = 'Configurations for Rubocop and other style enforcers/linters'
-  spec.homepage      = 'https://github.com/rainforestapp/rf-stylez'
+  spec.description   = "Configurations for Rubocop and other style enforcers/linters"
+  spec.homepage      = "https://github.com/rainforestapp/rf-stylez"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'bin'
-  spec.executables   = ['rf-stylez']
-  spec.require_paths = ['lib']
+  spec.bindir        = "bin"
+  spec.executables   = ["rf-stylez"]
+  spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rubocop', '1.41.1'
-  spec.add_runtime_dependency 'rubocop-rails', '2.17.4'
-  spec.add_runtime_dependency 'rubocop-rspec', '2.16.0'
-  spec.add_runtime_dependency 'reek', '~> 6.1'
-  spec.add_runtime_dependency 'get_env', '~> 0.2.0'
-  spec.add_runtime_dependency 'unparser', '~> 0.6'
+  spec.add_runtime_dependency "rubocop", "1.41.1"
+  spec.add_runtime_dependency "rubocop-rails", "2.17.4"
+  spec.add_runtime_dependency "rubocop-rspec", "2.16.0"
+  spec.add_runtime_dependency "reek", "~> 6.1"
+  spec.add_runtime_dependency "get_env", "~> 0.2.0"
+  spec.add_runtime_dependency "unparser", "~> 0.6"
 
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '>= 3.4'
-  spec.add_development_dependency 'byebug'
-  spec.add_development_dependency 'rspec_junit_formatter'
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", ">= 3.4"
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "rspec_junit_formatter"
 end

--- a/spec/rf/stylez_spec.rb
+++ b/spec/rf/stylez_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 RSpec.describe Rf::Stylez do
-  it 'config should be valid' do
+  it "config should be valid" do
     expect do
-      RuboCop::ConfigLoader.load_file('ruby/rubocop.yml')
+      RuboCop::ConfigLoader.load_file("ruby/rubocop.yml")
     end.not_to raise_error
   end
 end

--- a/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
+++ b/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Lint::NoBangStateMachineEvents do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers event names ending with a !' do
+  it "registers event names ending with a !" do
     expect_offense(<<~RUBY)
       state_machine :state do
         event :started! do
@@ -15,7 +15,7 @@ describe RuboCop::Cop::Lint::NoBangStateMachineEvents do
     RUBY
   end
 
-  it 'does not register event names without a !' do
+  it "does not register event names without a !" do
     expect_no_offenses(<<~RUBY)
       state_machine :state do
         event :started do
@@ -25,7 +25,7 @@ describe RuboCop::Cop::Lint::NoBangStateMachineEvents do
     RUBY
   end
 
-  it 'does not register call to event outside of state machine' do
+  it "does not register call to event outside of state machine" do
     expect_no_offenses(<<~RUBY)
       class SomethingElse
         event :started! do

--- a/spec/rubocop/cop/lint/no_grape_api.rb
+++ b/spec/rubocop/cop/lint/no_grape_api.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Lint::NoGrapeAPI do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when inheriting `Grape::API`' do
+  it "registers an offense when inheriting `Grape::API`" do
     expect_offense(<<~RUBY)
       class Foo < Grape::API
       ^^^^^^^^^^^^^^^^^^^^^^ Prefer inheriting `Api::AuthBase` or `Api::Base` instead of `Grape::API`.
@@ -13,7 +13,7 @@ describe RuboCop::Cop::Lint::NoGrapeAPI do
     RUBY
   end
 
-  it 'does not register an offense when using `Api::AuthBase`' do
+  it "does not register an offense when using `Api::AuthBase`" do
     expect_no_offenses(<<~RUBY)
       class Foo < Api::AuthBase
         puts('foo')
@@ -21,7 +21,7 @@ describe RuboCop::Cop::Lint::NoGrapeAPI do
     RUBY
   end
 
-  it 'does not register an offense when using `Api::AuthBase`' do
+  it "does not register an offense when using `Api::AuthBase`" do
     expect_no_offenses(<<~RUBY)
       class Foo < Api::Base
         puts('foo')
@@ -29,7 +29,7 @@ describe RuboCop::Cop::Lint::NoGrapeAPI do
     RUBY
   end
 
-  it 'does not register an offense when using `Grape::API::Helpers`' do
+  it "does not register an offense when using `Grape::API::Helpers`" do
     expect_no_offenses(<<~RUBY)
       module Api::Helpers::Run
         extend Grape::API::Helpers

--- a/spec/rubocop/cop/lint/no_http_party_spec.rb
+++ b/spec/rubocop/cop/lint/no_http_party_spec.rb
@@ -4,14 +4,14 @@ describe RuboCop::Cop::Lint::NoHTTParty do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when using `HTTParty`' do
+  it "registers an offense when using `HTTParty`" do
     expect_offense(<<~RUBY)
       HTTParty.get('foo')
       ^^^^^^^^^^^^^^^^^^^ Prefer `TimedRequest` instead of raw `HTTParty` calls.
     RUBY
   end
 
-  it 'does not register an offense when using `TimedRequest`' do
+  it "does not register an offense when using `TimedRequest`" do
     expect_no_offenses(<<~RUBY)
       TimedRequest.get('foo')
     RUBY

--- a/spec/rubocop/cop/lint/no_json_spec.rb
+++ b/spec/rubocop/cop/lint/no_json_spec.rb
@@ -4,14 +4,14 @@ describe RuboCop::Cop::Lint::NoJSON do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when using `#JSON`' do
+  it "registers an offense when using `#JSON`" do
     expect_offense(<<~RUBY)
       JSON
       ^^^^ Use `MultiJson` instead of `JSON`.
     RUBY
   end
 
-  it 'does not register an offense when using `#MultiJson`' do
+  it "does not register an offense when using `#MultiJson`" do
     expect_no_offenses(<<~RUBY)
       MultiJson
     RUBY

--- a/spec/rubocop/cop/lint/no_untyped_raise.rb
+++ b/spec/rubocop/cop/lint/no_untyped_raise.rb
@@ -4,9 +4,9 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  describe 'untyped' do
-    context 'raise' do
-      it 'registers an offense' do
+  describe "untyped" do
+    context "raise" do
+      it "registers an offense" do
         expect_offense(<<~RUBY)
           def foo
             raise 'foo'
@@ -16,8 +16,8 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
       end
     end
 
-    context 'fail' do
-      it 'registers an offense' do
+    context "fail" do
+      it "registers an offense" do
         expect_offense(<<~RUBY)
           def foo
             fail 'foo'
@@ -28,9 +28,9 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
     end
   end
 
-  describe 'typed' do
-    context 'raise' do
-      it 'registers no offense' do
+  describe "typed" do
+    context "raise" do
+      it "registers no offense" do
         expect_no_offenses(<<~RUBY)
         def foo
           raise ArgumentError, 'foo'
@@ -39,8 +39,8 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
       end
     end
 
-    context 'fail' do
-      it 'registers no offense' do
+    context "fail" do
+      it "registers no offense" do
         expect_no_offenses(<<~RUBY)
         def foo
           fail ArgumentError, 'foo'

--- a/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
+++ b/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Lint::NoVCRRecording do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when using vcr: { record: ... }' do
+  it "registers an offense when using vcr: { record: ... }" do
     expect_offense(<<~RUBY)
       describe Foo, vcr: { record: :new_episodes } do
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set :record option in VCR
@@ -19,7 +19,7 @@ describe RuboCop::Cop::Lint::NoVCRRecording do
     RUBY
   end
 
-  it 'handles multiple options passed to vcr' do
+  it "handles multiple options passed to vcr" do
     expect_offense(<<~RUBY)
       it 'works!', vcr: { tag: :workworkwork, record: :once } do
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set :record option in VCR
@@ -34,7 +34,7 @@ describe RuboCop::Cop::Lint::NoVCRRecording do
     RUBY
   end
 
-  it 'does not register an offense when not using :record' do
+  it "does not register an offense when not using :record" do
     expect_no_offenses(<<~RUBY)
       context 'with no recording', vcr: true do
         specify { expect(true).to eq(true) }

--- a/spec/rubocop/cop/lint/obscure_spec.rb
+++ b/spec/rubocop/cop/lint/obscure_spec.rb
@@ -4,34 +4,34 @@ describe RuboCop::Cop::Lint::Obscure do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'registers an offense when using flipflop' do
+  it "registers an offense when using flipflop" do
     expect_offense(<<~RUBY)
       puts 'foo' if 'a'..'b'
                     ^^^^^^^^ Do not use the flipflop operator
     RUBY
   end
 
-  it 'registers an offense when using eflipflop' do
+  it "registers an offense when using eflipflop" do
     expect_offense(<<~RUBY)
       puts 'foo' if 'a'...'b'
                     ^^^^^^^^^ Do not use the flipflop operator
     RUBY
   end
 
-  it 'registers an offense when using String#%' do
+  it "registers an offense when using String#%" do
     expect_offense(<<~RUBY)
       puts 'foo' % 'bar'
            ^^^^^^^^^^^^^ Do not use String#%
     RUBY
   end
 
-  it 'does not register an offense when using incluse Range `..`' do
+  it "does not register an offense when using incluse Range `..`" do
     expect_no_offenses(<<~RUBY)
       1..2
     RUBY
   end
 
-  it 'does not register an offense when using exclusive Range `...`' do
+  it "does not register an offense when using exclusive Range `...`" do
     expect_no_offenses(<<~RUBY)
       1...2
     RUBY

--- a/spec/rubocop/cop/lint/use_positive_int32_validator_spec.rb
+++ b/spec/rubocop/cop/lint/use_positive_int32_validator_spec.rb
@@ -4,7 +4,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
   let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
 
-  it 'handles a big params with nested params and such' do
+  it "handles a big params with nested params and such" do
     expect_offense(<<~RUBY)
       params :example_params do
         optional :id, type: Integer
@@ -40,7 +40,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         RUBY
       end
 
-      it 'handles different parameter orders' do
+      it "handles different parameter orders" do
         expect_offense(<<~RUBY)
           params do
             #{method} :id, desc: 'Comment ID', type: Integer
@@ -49,7 +49,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         RUBY
       end
 
-      it 'handles multiple arguments' do
+      it "handles multiple arguments" do
         expect_offense(<<~RUBY)
         params do
           #{method} :id, type: Integer, desc: 'Comment ID'
@@ -59,7 +59,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         RUBY
       end
 
-      it 'handles multiple arguments, in mixed order' do
+      it "handles multiple arguments, in mixed order" do
         expect_offense(<<~RUBY)
         params do
           requires :text, type: String
@@ -72,7 +72,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         RUBY
       end
 
-      it 'handles named params blocks' do
+      it "handles named params blocks" do
         expect_offense(<<~RUBY)
         params :test do
           #{method} :id, type: Integer, desc: 'Comment ID'
@@ -82,13 +82,13 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
       end
     end
 
-    it 'does not register an offense when not in a params block' do
+    it "does not register an offense when not in a params block" do
       expect_no_offenses(<<~RUBY)
         #{method} :id, type: Integer, desc: 'Comment ID'
       RUBY
     end
 
-    context 'does not register an offense when positive_int32 is true' do
+    context "does not register an offense when positive_int32 is true" do
       specify do
         expect_no_offenses(<<~RUBY)
           params :test do
@@ -97,7 +97,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         RUBY
       end
 
-      it 'handles a bunch of arguments' do
+      it "handles a bunch of arguments" do
         expect_no_offenses(<<~RUBY)
           params :test do
             #{method} :id, type: Integer, desc: 'Comment ID', documentation: { blah: 'blah' }, positive_int32: true
@@ -106,7 +106,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
       end
     end
 
-    context 'does not register an offense when positive_int32 is false' do
+    context "does not register an offense when positive_int32 is false" do
       specify do
         expect_no_offenses(<<~RUBY)
           params :test do
@@ -116,7 +116,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
       end
     end
 
-    context 'does not register an offense when positive_int32 takes in a value' do
+    context "does not register an offense when positive_int32 takes in a value" do
       specify do
         expect_no_offenses(<<~RUBY)
           params :test do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'rubocop'
-require 'rubocop/rspec/support'
-require_relative '../lib/rubocop/cop/lint/no_json'
-require_relative '../lib/rubocop/cop/lint/no_http_party'
-require_relative '../lib/rubocop/cop/lint/obscure'
-require_relative '../lib/rubocop/cop/lint/no_grape_api'
-require_relative '../lib/rubocop/cop/lint/use_positive_int32_validator'
-require_relative '../lib/rubocop/cop/lint/no_bang_state_machine_events'
-require_relative '../lib/rubocop/cop/lint/no_untyped_raise'
-require_relative '../lib/rubocop/cop/lint/no_vcr_recording'
+require "rubocop"
+require "rubocop/rspec/support"
+require_relative "../lib/rubocop/cop/lint/no_json"
+require_relative "../lib/rubocop/cop/lint/no_http_party"
+require_relative "../lib/rubocop/cop/lint/obscure"
+require_relative "../lib/rubocop/cop/lint/no_grape_api"
+require_relative "../lib/rubocop/cop/lint/use_positive_int32_validator"
+require_relative "../lib/rubocop/cop/lint/no_bang_state_machine_events"
+require_relative "../lib/rubocop/cop/lint/no_untyped_raise"
+require_relative "../lib/rubocop/cop/lint/no_vcr_recording"
 
 RSpec.configure do |config|
   config.include RuboCop::RSpec::ExpectOffense


### PR DESCRIPTION
There are 3 offenses remaining:
```
lib/rf/stylez.rb:15:3: C: Style/Documentation: Missing top-level documentation comment for module Rf::Stylez.
  module Stylez
  ^^^^^^^^^^^^^
lib/rf/stylez/update_check.rb:9:5: C: Style/Documentation: Missing top-level documentation comment for module Rf::Stylez::UpdateCheck.
    module UpdateCheck
    ^^^^^^^^^^^^^^^^^^
lib/rf/stylez/update_check.rb:17:11: W: Lint/NoJSON: Use MultiJson instead of JSON.
          JSON.parse(Net::HTTP.get(RUBYGEMS_URL))["version"]
          ^^^^
```