### PR TITLE
Upgrade to Ruby 3.2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
 
   test:
     docker:
-      - image: circleci/ruby:2.7.1
+      - image: cimg/ruby:3.2.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -47,7 +47,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: circleci/ruby:2.7.1
+      - image: cimg/ruby:3.2.0
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,6 @@
 version: 2.1
 
 jobs:
-  style_check:
-    docker:
-      - image: gcr.io/rf-public-images/circlemator:latest
-    steps:
-      - checkout
-      - run:
-          name: Style check
-          command: circlemator style-check --base-branch=master
-
   test:
     docker:
       - image: cimg/ruby:3.2.0
@@ -74,11 +65,6 @@ workflows:
       - test:
           context:
             - DockerHub
-      - style_check:
-          filters:
-            branches:
-              ignore:
-                - master
       - push_to_rubygems:
           filters:
             branches:

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -1,0 +1,40 @@
+name: Pronto
+on: [pull_request]
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  pronto:
+    runs-on: ubuntu-latest
+    env:
+      # `MAKE="make --jobs $(nproc)"` is from
+      # https://build.betterup.com/one-weird-trick-that-will-speed-up-your-bundle-install/
+      # Only works for MRI
+      #
+      # Using 4 since https://github.com/ruby/setup-ruby use 4
+      MAKE: "make --jobs 4"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      # Set the depth to 100 and hope this won't fail for branches with a lot of little commits
+      - run: |
+          git fetch --no-tags --prune --depth=100 origin +refs/heads/*:refs/remotes/origin/*
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version:  "3.2.0"
+          # Run `bundle install` with cache when `true`
+          bundler-cache: true
+      - name: Setup pronto
+        run: gem install pronto pronto-rubocop
+      - name: Run Pronto
+        run: bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
+        env:
+          PRONTO_PULL_REQUEST_ID: ${{ github.event.pull_request.number }}
+          PRONTO_GITHUB_ACCESS_TOKEN: "${{ github.token }}"
+          BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 .byebug_history
+.tool-versions

--- a/lib/rf/stylez/update_check.rb
+++ b/lib/rf/stylez/update_check.rb
@@ -4,8 +4,6 @@ require 'json'
 require 'net/http'
 require 'logger'
 
-require 'semantic_versioning'
-
 module Rf
   module Stylez
     module UpdateCheck
@@ -13,9 +11,9 @@ module Rf
 
       def self.check
         logger = Logger.new(STDOUT)
-        current_version = SemanticVersioning::Version.new(VERSION)
+        current_version = Gem::Version.new(VERSION)
 
-        remote_version = SemanticVersioning::Version.new(
+        remote_version = Gem::Version.new(
           JSON.parse(Net::HTTP.get(RUBYGEMS_URL))['version']
         )
         if current_version >= remote_version

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.16.0'
+    VERSION = "0.16.0"
   end
 end

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = '0.15.1'
+    VERSION = '0.16.0'
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -25,6 +25,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'reek', '~> 6.1'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'
   spec.add_runtime_dependency 'unparser', '~> 0.6'
+  spec.add_runtime_dependency 'pronto', '~> 0.11.1'
+  spec.add_runtime_dependency 'pronto-rubocop', '~> 0.11.4'
 
   spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'rake', '~> 13.0'

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -1,36 +1,38 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'rf/stylez/version'
+require "rf/stylez/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = 'rf-stylez'
+  spec.name          = "rf-stylez"
   spec.version       = Rf::Stylez::VERSION
-  spec.authors       = ['Emanuel Evans']
-  spec.email         = ['emanuel@rainforestqa.com']
-  spec.license       = 'MIT'
+  spec.authors       = ["Emanuel Evans"]
+  spec.email         = ["emanuel@rainforestqa.com"]
+  spec.license       = "MIT"
 
   spec.summary       = %q{Styles for Rainforest code}
-  spec.description   = 'Configurations for Rubocop and other style enforcers/linters'
-  spec.homepage      = 'https://github.com/rainforestapp/rf-stylez'
+  spec.description   = "Configurations for Rubocop and other style enforcers/linters"
+  spec.homepage      = "https://github.com/rainforestapp/rf-stylez"
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.bindir        = 'bin'
-  spec.executables   = ['rf-stylez']
-  spec.require_paths = ['lib']
+  spec.bindir        = "bin"
+  spec.executables   = ["rf-stylez"]
+  spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rubocop', '1.41.1'
-  spec.add_runtime_dependency 'rubocop-rails', '2.17.4'
-  spec.add_runtime_dependency 'rubocop-rspec', '2.16.0'
-  spec.add_runtime_dependency 'reek', '~> 6.1'
-  spec.add_runtime_dependency 'get_env', '~> 0.2.0'
-  spec.add_runtime_dependency 'unparser', '~> 0.6'
-  spec.add_runtime_dependency 'pronto', '~> 0.11.1'
-  spec.add_runtime_dependency 'pronto-rubocop', '~> 0.11.4'
+  spec.add_runtime_dependency "rubocop", "1.41.1"
+  spec.add_runtime_dependency "rubocop-rails", "2.17.4"
+  spec.add_runtime_dependency "rubocop-rspec", "2.16.0"
+  spec.add_runtime_dependency "reek", "~> 6.1"
+  spec.add_runtime_dependency "get_env", "~> 0.2.0"
+  spec.add_runtime_dependency "unparser", "~> 0.6"
+  spec.add_runtime_dependency "pronto", "~> 0.11.1"
+  spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.4"
 
-  spec.add_development_dependency 'bundler', '~> 2.1'
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec', '>= 3.4'
-  spec.add_development_dependency 'byebug'
-  spec.add_development_dependency 'rspec_junit_formatter'
+  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", ">= 3.4"
+  spec.add_development_dependency "byebug"
+  spec.add_development_dependency "rspec_junit_formatter"
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -19,12 +19,11 @@ Gem::Specification.new do |spec|
   spec.executables   = ['rf-stylez']
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'rubocop', '1.15.0'
-  spec.add_runtime_dependency 'rubocop-rails', '2.10.1'
-  spec.add_runtime_dependency 'rubocop-rspec', '2.3.0'
+  spec.add_runtime_dependency 'rubocop', '1.41.1'
+  spec.add_runtime_dependency 'rubocop-rails', '2.17.4'
+  spec.add_runtime_dependency 'rubocop-rspec', '2.16.0'
   spec.add_runtime_dependency 'reek', '~> 6.1'
   spec.add_runtime_dependency 'get_env', '~> 0.2.0'
-  spec.add_runtime_dependency 'semantic_versioning', '~> 0.2'
   spec.add_runtime_dependency 'unparser', '~> 0.6'
 
   spec.add_development_dependency 'bundler', '~> 2.1'


### PR DESCRIPTION
- I had to deprecate `SemanticVersioning` gem dependency which was causing issues and seems no longer maintained. Moreover it seems it was used for something that is included in `Gem` standard lib (https://medium.com/little-programming-joys/how-to-compare-version-strings-in-ruby-ced0916a4b71)

**THEN:**
After merge, we need to release the new gem version to rubygems (see README)