### PR TITLE
RF-26495 Remove bundler/setup from bin/rf-stylez

### DIFF
--- a/bin/rf-stylez
+++ b/bin/rf-stylez
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
 require "rf/stylez"
 
 command = ARGV.first

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "0.16.0"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
With `require 'bundler/setup'` running this command will use the Gemfile
in the current working directory. If the Gemfile doesn't include
rf-stylze then this means the path to the rf-stylez libraries is removed
from the $LOAD_PATH and the command will fail to require `rf/stylez`.
