### PR TITLE
RF-26632 Remove circlemator reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ This is a place for style configurations for [Rainforest QA](https://www.rainfor
 - pull latest master
 - run `rake release:source_control_push`
 - CI/CD will take care of releasing rf-stylez to rubygems
-- Update circlemator `bundle update rf-stylez`
 
 ## Adding `rf-stylez` to a new project
 


### PR DESCRIPTION
As part of an effort to deprecate Circlemator repository, we are removing all of its usages and references.