### PR TITLE
Update runtime gems and enable OpenStruct linter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.2.0
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -32,7 +32,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.2.0
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -9,7 +9,9 @@ permissions:
 
 jobs:
   pronto:
+
     runs-on: ubuntu-latest
+
     env:
       # `MAKE="make --jobs $(nproc)"` is from
       # https://build.betterup.com/one-weird-trick-that-will-speed-up-your-bundle-install/
@@ -20,18 +22,20 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
-      # Set the depth to 100 and hope this won't fail for branches with a lot of little commits
-      - run: |
-          git fetch --no-tags --prune --depth=100 origin +refs/heads/*:refs/remotes/origin/*
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 100
+      - run: git fetch --no-tags --prune --depth=100 origin "+refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
+
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version:  "3.2.0"
-          # Run `bundle install` with cache when `true`
+          ruby-version:  "3.2.2"
           bundler-cache: true
+
       - name: Setup pronto
         run: gem install pronto pronto-rubocop
+
       - name: Run Pronto
         run: bundle exec pronto run -f github_status github_pr -c origin/${{ github.base_ref }}
         env:

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -21,16 +21,16 @@ Gem::Specification.new do |spec|
   spec.executables   = ["rf-stylez"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "1.41.1"
-  spec.add_runtime_dependency "rubocop-rails", "2.17.4"
-  spec.add_runtime_dependency "rubocop-rspec", "2.16.0"
+  spec.add_runtime_dependency "rubocop", "1.54.1"
+  spec.add_runtime_dependency "rubocop-rails", "2.20.2"
+  spec.add_runtime_dependency "rubocop-rspec", "2.22.0"
   spec.add_runtime_dependency "reek", "~> 6.1"
   spec.add_runtime_dependency "get_env", "~> 0.2.0"
   spec.add_runtime_dependency "unparser", "~> 0.6"
   spec.add_runtime_dependency "pronto", "~> 0.11.1"
-  spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.4"
+  spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.5"
 
-  spec.add_development_dependency "bundler", "~> 2.1"
+  spec.add_development_dependency "bundler", "~> 2.4"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rspec", ">= 3.4"
   spec.add_development_dependency "byebug"

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -180,6 +180,8 @@ Style/Documentation:
   Enabled: true
 Style/DocumentationMethod:
   Enabled: false
+Style/OpenStructUse:
+  Enabled: true
 
 Layout/LineLength:
   Enabled: true

--- a/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
+++ b/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
@@ -8,7 +8,7 @@ describe RuboCop::Cop::Lint::NoBangStateMachineEvents do
     expect_offense(<<~RUBY)
       state_machine :state do
         event :started! do
-        ^^^^^^^^^^^^^^^ Event names ending with a `!` define `!`-ended methods that do not raise
+        ^^^^^^^^^^^^^^^ Lint/NoBangStateMachineEvents: Event names ending with a `!` define `!`-ended methods that do not raise
           transition :queued => :in_progress
         end
       end

--- a/spec/rubocop/cop/lint/no_http_party_spec.rb
+++ b/spec/rubocop/cop/lint/no_http_party_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Lint::NoHTTParty do
   it 'registers an offense when using `HTTParty`' do
     expect_offense(<<~RUBY)
       HTTParty.get('foo')
-      ^^^^^^^^^^^^^^^^^^^ Prefer `TimedRequest` instead of raw `HTTParty` calls.
+      ^^^^^^^^^^^^^^^^^^^ Lint/NoHTTParty: Prefer `TimedRequest` instead of raw `HTTParty` calls.
     RUBY
   end
 

--- a/spec/rubocop/cop/lint/no_json_spec.rb
+++ b/spec/rubocop/cop/lint/no_json_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Lint::NoJSON do
   it 'registers an offense when using `#JSON`' do
     expect_offense(<<~RUBY)
       JSON
-      ^^^^ Use `MultiJson` instead of `JSON`.
+      ^^^^ Lint/NoJSON: Use `MultiJson` instead of `JSON`.
     RUBY
   end
 

--- a/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
+++ b/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
@@ -7,7 +7,7 @@ describe RuboCop::Cop::Lint::NoVCRRecording do
   it 'registers an offense when using vcr: { record: ... }' do
     expect_offense(<<~RUBY)
       describe Foo, vcr: { record: :new_episodes } do
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set :record option in VCR
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/NoVCRRecording: Do not set :record option in VCR
         include_examples 'all the networks!'
       end
     RUBY
@@ -22,7 +22,7 @@ describe RuboCop::Cop::Lint::NoVCRRecording do
   it 'handles multiple options passed to vcr' do
     expect_offense(<<~RUBY)
       it 'works!', vcr: { tag: :workworkwork, record: :once } do
-                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Do not set :record option in VCR
+                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/NoVCRRecording: Do not set :record option in VCR
         expect(let_me_google_that_for_you).to be_full_of_sass
       end
     RUBY

--- a/spec/rubocop/cop/lint/obscure_spec.rb
+++ b/spec/rubocop/cop/lint/obscure_spec.rb
@@ -7,21 +7,21 @@ describe RuboCop::Cop::Lint::Obscure do
   it 'registers an offense when using flipflop' do
     expect_offense(<<~RUBY)
       puts 'foo' if 'a'..'b'
-                    ^^^^^^^^ Do not use the flipflop operator
+                    ^^^^^^^^ Lint/Obscure: Do not use the flipflop operator
     RUBY
   end
 
   it 'registers an offense when using eflipflop' do
     expect_offense(<<~RUBY)
       puts 'foo' if 'a'...'b'
-                    ^^^^^^^^^ Do not use the flipflop operator
+                    ^^^^^^^^^ Lint/Obscure: Do not use the flipflop operator
     RUBY
   end
 
   it 'registers an offense when using String#%' do
     expect_offense(<<~RUBY)
       puts 'foo' % 'bar'
-           ^^^^^^^^^^^^^ Do not use String#%
+           ^^^^^^^^^^^^^ Lint/Obscure: Do not use String#%
     RUBY
   end
 

--- a/spec/rubocop/cop/lint/use_positive_int32_validator_spec.rb
+++ b/spec/rubocop/cop/lint/use_positive_int32_validator_spec.rb
@@ -8,18 +8,18 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
     expect_offense(<<~RUBY)
       params :example_params do
         optional :id, type: Integer
-                      ^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                      ^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
         optional :abc, type: String
         optional :edf, types: [String, Array[String]]
         optional :ghi, type: Hash, documentation: { hidden: true }
         optional :elements, type: Array, coerce_with: abcdefg do
           optional :zyx, type: Boolean
           optional :id, type: Integer
-                        ^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                        ^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
           requires :type, type: String, values: ['123', 'abc']
           requires :element, type: Hash do
             optional :id, type: Integer
-                          ^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                          ^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
             optional :action, type: String
             all_or_none_of :action, :response
           end
@@ -35,7 +35,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         expect_offense(<<~RUBY)
           params do
             #{method} :id, type: Integer, desc: 'Comment ID'
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
           end
         RUBY
       end
@@ -44,7 +44,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         expect_offense(<<~RUBY)
           params do
             #{method} :id, desc: 'Comment ID', type: Integer
-                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
           end
         RUBY
       end
@@ -53,7 +53,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         expect_offense(<<~RUBY)
         params do
           #{method} :id, type: Integer, desc: 'Comment ID'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
           requires :text, type: String
         end
         RUBY
@@ -64,10 +64,10 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         params do
           requires :text, type: String
           #{method} :id, type: Integer, desc: 'Comment ID'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
           requires :text, type: String
           requires :id2, type: Integer, desc: 'Comment ID'
-                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
         end
         RUBY
       end
@@ -76,7 +76,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
         expect_offense(<<~RUBY)
         params :test do
           #{method} :id, type: Integer, desc: 'Comment ID'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
         end
         RUBY
       end


### PR DESCRIPTION
* Updated the runtime dependency gems to their latest version
* Added linter to avoid `OpenStruct` usage
* Improved `pronto` checks performance
* Updated to version `1.0.1`