### PR TITLE
Set target ruby version 3.2

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.2
   DisabledByDefault: true
   Include:
     - '**/*.rb'


### PR DESCRIPTION
We were seeing lots of warnings due to using the new keyword syntax added in ruby 3.1 I think.
