### PR TITLE
RF-32115 start using rubocop rails

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,1 +1,16 @@
 require: rubocop-rails
+
+Rails/AddColumnIndex:
+  Enabled: true
+Rails/DuplicateAssociation:
+  Enabled: true
+Rails/Presence:
+  Enabled: true
+Rails/Present:
+  Enabled: true
+Rails/ReversibleMigration:
+  Enabled: true
+Rails/ReversibleMigrationMethodDefinition:
+  Enabled: true
+Rails/TransactionExitStatement:
+  Enabled: true

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -21,18 +21,18 @@ Gem::Specification.new do |spec|
   spec.executables   = ["rf-stylez"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "1.54.2"
-  spec.add_runtime_dependency "rubocop-rails", "2.20.2"
-  spec.add_runtime_dependency "rubocop-rspec", "2.22.0"
-  spec.add_runtime_dependency "reek", "~> 6.1"
-  spec.add_runtime_dependency "get_env", "~> 0.2.0"
+  spec.add_runtime_dependency "rubocop", "1.59.0"
+  spec.add_runtime_dependency "rubocop-rails", "2.23.1"
+  spec.add_runtime_dependency "rubocop-rspec", "2.26.1"
+  spec.add_runtime_dependency "reek", "~> 6.2"
+  spec.add_runtime_dependency "get_env", "~> 0.2.1"
   spec.add_runtime_dependency "unparser", "~> 0.6"
-  spec.add_runtime_dependency "pronto", "~> 0.11.1"
+  spec.add_runtime_dependency "pronto", "~> 0.11.2"
   spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.5"
 
   spec.add_development_dependency "bundler", "~> 2.4"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", ">= 3.4"
+  spec.add_development_dependency "rake", "~> 13.1"
+  spec.add_development_dependency "rspec", ">= 3.12"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rspec_junit_formatter"
 end


### PR DESCRIPTION
I enabled only some `rubocop-rails` cops that I thought should be OK by everyone.
Here is the full list of cops to see if we want to enable more https://docs.rubocop.org/rubocop-rails/cops.html

Another topic for discussion is that we have `DisabledByDefault: true` configured, so we have to opt-in to every cop rule we want. I wonder if we should try to reverse that configuration and opt out of what we don't want.

