### PR TITLE
Change cops default to true and we have to opt-out

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,9 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "bundler", "~> 2.4"
+gem "byebug"
+gem "rake", "~> 13.1"
+gem "rspec", ">= 3.12"
+gem "rspec_junit_formatter"

--- a/lib/rf/stylez/update_check.rb
+++ b/lib/rf/stylez/update_check.rb
@@ -11,7 +11,7 @@ module Rf
       RUBYGEMS_URL = URI("https://rubygems.org/api/v1/gems/rf-stylez.json").freeze
 
       def self.check
-        logger = Logger.new(STDOUT)
+        logger = Logger.new($stdout)
         current_version = Gem::Version.new(VERSION)
 
         remote_version = Gem::Version.new(

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.0.3"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/rubocop/cop/lint/no_grape_api.rb
+++ b/lib/rubocop/cop/lint/no_grape_api.rb
@@ -19,6 +19,7 @@ module RuboCop
 
         def on_class(node)
           return unless inherits_Grape_API?(node)
+
           add_offense(node)
         end
       end

--- a/lib/rubocop/cop/lint/no_http_party.rb
+++ b/lib/rubocop/cop/lint/no_http_party.rb
@@ -16,6 +16,7 @@ module RuboCop
 
         def on_send(node)
           return unless is_HTTParty?(node)
+
           add_offense(node)
         end
       end

--- a/lib/rubocop/cop/lint/no_json.rb
+++ b/lib/rubocop/cop/lint/no_json.rb
@@ -17,6 +17,7 @@ module RuboCop
 
         def on_const(node)
           return unless is_JSON?(node)
+
           add_offense(node)
         end
       end

--- a/lib/rubocop/cop/lint/no_untyped_raise.rb
+++ b/lib/rubocop/cop/lint/no_untyped_raise.rb
@@ -17,6 +17,7 @@ module RuboCop
 
         def on_send(node)
           return unless is_untyped_raise?(node)
+
           add_offense(node)
         end
       end

--- a/lib/rubocop/cop/lint/obscure.rb
+++ b/lib/rubocop/cop/lint/obscure.rb
@@ -36,6 +36,7 @@ module RuboCop
 
         def on_send(node)
           return unless is_stringformat?(node)
+
           add_offense(node, message: "Do not use String#%")
         end
       end

--- a/lib/rubocop/cop/lint/use_positive_int32_validator.rb
+++ b/lib/rubocop/cop/lint/use_positive_int32_validator.rb
@@ -18,9 +18,9 @@ module RuboCop
 
         # check if the param is `requires` / `optional`
         def_node_search :find_params_hashes, <<~PATTERN
-        (send nil? {:requires :optional}
-          (sym _)
-          $(hash ...) ...)
+          (send nil? {:requires :optional}
+            (sym _)
+            $(hash ...) ...)
         PATTERN
         # check if hash contains `type: Integer`
         def_node_search :is_type_integer?, "(pair (sym :type) (const nil? :Integer))"
@@ -29,10 +29,9 @@ module RuboCop
 
         def on_block(node)
           return unless (hash = find_params_hashes(node))
+
           hash.each do |param|
-            if is_type_integer?(param) && !validates_integer?(param)
-              add_offense(param)
-            end
+            add_offense(param) if is_type_integer?(param) && !validates_integer?(param)
           end
         end
       end

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,16 +1,10 @@
 require: rubocop-rails
 
-Rails/AddColumnIndex:
-  Enabled: true
-Rails/DuplicateAssociation:
-  Enabled: true
-Rails/Presence:
-  Enabled: true
-Rails/Present:
-  Enabled: true
-Rails/ReversibleMigration:
-  Enabled: true
-Rails/ReversibleMigrationMethodDefinition:
-  Enabled: true
-Rails/TransactionExitStatement:
-  Enabled: true
+Rails/I18nLocaleTexts:
+  Enabled: false
+Rails/ActionOrder:
+  Enabled: false
+Rails/HasManyOrHasOneDependent:
+  Enabled: false
+Rails/TimeZone:
+  Enabled: false

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path("../lib", __FILE__)
@@ -29,10 +28,4 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "unparser", "~> 0.6"
   spec.add_runtime_dependency "pronto", "~> 0.11.2"
   spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.5"
-
-  spec.add_development_dependency "bundler", "~> 2.4"
-  spec.add_development_dependency "rake", "~> 13.1"
-  spec.add_development_dependency "rspec", ">= 3.12"
-  spec.add_development_dependency "byebug"
-  spec.add_development_dependency "rspec_junit_formatter"
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   TargetRubyVersion: 3.2
-  DisabledByDefault: true
+  NewCops: enable
+  SuggestExtensions: false
   Include:
     - '**/*.rb'
     - '**/*.rake'
@@ -40,100 +41,13 @@ Lint/NoVCRRecording:
     - spec/**/*
 
 # Good style cops
-Layout/BlockAlignment:
-  Enabled: true
-Layout/EndAlignment:
-  Enabled: true
-Layout/DefEndAlignment:
-  Enabled: true
-Layout/ConditionPosition:
-  Enabled: true
-Layout/TrailingEmptyLines:
-  Enabled: true
-Layout/TrailingWhitespace:
-  Enabled: true
 Layout/EmptyLineBetweenDefs:
   Enabled: true
   EmptyLineBetweenClassDefs: false
-Layout/IndentationWidth:
-  Enabled: true
-Layout/AccessModifierIndentation:
-  Enabled: true
-Layout/ArrayAlignment:
-  Enabled: true
-Layout/HashAlignment:
-  Enabled: true
-Layout/ParameterAlignment:
-  Enabled: true
-Layout/CaseIndentation:
-  Enabled: true
-Layout/ClosingParenthesisIndentation:
-  Enabled: true
-Layout/CommentIndentation:
-  Enabled: true
-Layout/ElseAlignment:
-  Enabled: true
-Layout/EmptyLines:
-  Enabled: true
-Layout/EndOfLine:
-  Enabled: true
-Layout/ExtraSpacing:
-  Enabled: true
-Layout/InitialIndentation:
-  Enabled: true
-Layout/IndentationConsistency:
-  Enabled: true
-Layout/IndentationStyle:
-  Enabled: true
-Layout/FirstHashElementIndentation:
-  Enabled: true
-Layout/LeadingCommentSpace:
-  Enabled: true
-Layout/RescueEnsureAlignment:
-  Enabled: true
-Layout/SpaceBeforeFirstArg:
-  Enabled: true
-Layout/SpaceAfterColon:
-  Enabled: true
-Layout/SpaceAfterComma:
-  Enabled: true
-Layout/SpaceAfterMethodName:
-  Enabled: true
-Layout/SpaceBeforeBlockBraces:
-  Enabled: true
-Layout/SpaceBeforeComma:
-  Enabled: true
-Layout/SpaceInsideParens:
-  Enabled: true
 
-Naming/MethodName:
-  Enabled: true
-Naming/VariableName:
-  Enabled: true
-Naming/ClassAndModuleCamelCase:
-  Enabled: true
-Naming/ConstantName:
-  Enabled: true
-Naming/FileName:
-  Enabled: true
-
-Style/EndBlock:
-  Enabled: true
-Style/SpecialGlobalVars:
-  Enabled: true
-Style/GlobalVars:
-  Enabled: true
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
-Style/BlockDelimiters:
-  Enabled: true
-Style/DefWithParentheses:
-  Enabled: true
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: true
-Style/InfiniteLoop:
-  Enabled: true
 Style/StringLiterals:
   Description: 'Checks if uses of quotes match the configured preference.'
   StyleGuide: '#consistent-string-literals'
@@ -147,16 +61,6 @@ Style/StringLiterals:
   # If `true`, strings which span multiple lines using `\` for continuation must
   # use the same type of quotes on each line.
   ConsistentQuotesInMultiline: true
-Style/AndOr:
-  Enabled: true
-Style/Not:
-  Enabled: true
-Style/MutableConstant:
-  Enabled: true
-Style/HashSyntax:
-  Enabled: true
-Style/RedundantFreeze:
-  Enabled: true
 Style/TrailingCommaInArguments:
   Enabled: true
   EnforcedStyleForMultiline: no_comma
@@ -166,30 +70,12 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: consistent_comma
-Style/MultilineIfThen:
-  Enabled: true
-Style/Semicolon:
-  Enabled: true
-Style/SignalException:
-  Enabled: true
-Style/SymbolProc:
-  Enabled: true
-Style/RegexpLiteral:
-  Enabled: true
-Style/Documentation:
-  Enabled: true
-Style/DocumentationMethod:
-  Enabled: false
-Style/OpenStructUse:
-  Enabled: true
 
 Layout/LineLength:
   Enabled: true
   Max: 120
   AllowHeredoc: true
   AllowURI: true
-Layout/EmptyLineAfterMagicComment:
-  Enabled: true
 
 # Dumb lint cops
 Lint/AmbiguousOperator:
@@ -197,4 +83,66 @@ Lint/AmbiguousOperator:
 Lint/NonLocalExitFromIterator:
   Enabled: false
 Lint/AmbiguousRegexpLiteral:
+  Enabled: false
+
+Metrics/MethodLength:
+  Enabled: false
+
+Naming/AccessorMethodName:
+  Enabled: false
+Naming/PredicateName:
+  Enabled: false
+Naming/HeredocDelimiterNaming:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+RSpec/NamedSubject:
+  Enabled: false
+RSpec/ExampleLength:
+  Enabled: false
+RSpec/MessageSpies:
+  Enabled: false
+RSpec/StubbedMock:
+  Enabled: false
+RSpec/IndexedLet:
+  Enabled: false
+RSpec/LetSetup:
+  Enabled: false
+RSpec/ExpectChange:
+  Enabled: false
+RSpec/ContextWording:
+  Enabled: false
+RSpec/NestedGroups:
+  Enabled: false
+RSpec/MetadataStyle:
+  Enabled: false
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+RSpec/BeEq:
+  Enabled: false
+RSpec/AnyInstance:
+  Enabled: false
+
+Style/DocumentationMethod:
+  Enabled: false
+Style/SafeNavigation:
+  Enabled: false
+Style/PercentLiteralDelimiters:
+  Enabled: false
+Style/SymbolArray:
+  Enabled: false
+Style/ClassAndModuleChildren:
+  Enabled: false
+Style/GuardClause:
+  Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: false
+Style/WordArray:
+  Enabled: false
+Style/FormatString:
+  Enabled: false
+Style/FormatStringToken:
+  Enabled: false
+Style/MapToHash:
   Enabled: false

--- a/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
+++ b/spec/rubocop/cop/lint/no_bang_state_machine_events_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::NoBangStateMachineEvents do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it "registers event names ending with a !" do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/no_grape_api_spec.rb
+++ b/spec/rubocop/cop/lint/no_grape_api_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::NoGrapeAPI do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it "registers an offense when inheriting `Grape::API`" do
     expect_offense(<<~RUBY)
       class Foo < Grape::API
-      ^^^^^^^^^^^^^^^^^^^^^^ Prefer inheriting `Api::AuthBase` or `Api::Base` instead of `Grape::API`.
+      ^^^^^^^^^^^^^^^^^^^^^^ Lint/NoGrapeAPI: Prefer inheriting `Api::AuthBase` or `Api::Base` instead of `Grape::API`.
         puts('foo')
       end
     RUBY
@@ -21,7 +22,7 @@ describe RuboCop::Cop::Lint::NoGrapeAPI do
     RUBY
   end
 
-  it "does not register an offense when using `Api::AuthBase`" do
+  it "does not register an offense when using `Api::Base`" do
     expect_no_offenses(<<~RUBY)
       class Foo < Api::Base
         puts('foo')

--- a/spec/rubocop/cop/lint/no_htt_party_spec.rb
+++ b/spec/rubocop/cop/lint/no_htt_party_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::NoHTTParty do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it "registers an offense when using `HTTParty`" do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/no_json_spec.rb
+++ b/spec/rubocop/cop/lint/no_json_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::NoJSON do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it "registers an offense when using `#JSON`" do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/no_untyped_raise_spec.rb
+++ b/spec/rubocop/cop/lint/no_untyped_raise_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::NoUntypedRaise do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   describe "untyped" do
     context "raise" do
@@ -10,7 +11,7 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
         expect_offense(<<~RUBY)
           def foo
             raise 'foo'
-            ^^^^^^^^^^^ Do not raise untyped exceptions, specify the error type so it can be rescued specifically.
+            ^^^^^^^^^^^ Lint/NoUntypedRaise: Do not raise untyped exceptions, specify the error type so it can be rescued specifically.
           end
         RUBY
       end
@@ -21,7 +22,7 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
         expect_offense(<<~RUBY)
           def foo
             fail 'foo'
-            ^^^^^^^^^^ Do not raise untyped exceptions, specify the error type so it can be rescued specifically.
+            ^^^^^^^^^^ Lint/NoUntypedRaise: Do not raise untyped exceptions, specify the error type so it can be rescued specifically.
           end
         RUBY
       end
@@ -32,9 +33,9 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
     context "raise" do
       it "registers no offense" do
         expect_no_offenses(<<~RUBY)
-        def foo
-          raise ArgumentError, 'foo'
-        end
+          def foo
+            raise ArgumentError, 'foo'
+          end
         RUBY
       end
     end
@@ -42,9 +43,9 @@ describe RuboCop::Cop::Lint::NoUntypedRaise do
     context "fail" do
       it "registers no offense" do
         expect_no_offenses(<<~RUBY)
-        def foo
-          fail ArgumentError, 'foo'
-        end
+          def foo
+            fail ArgumentError, 'foo'
+          end
         RUBY
       end
     end

--- a/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
+++ b/spec/rubocop/cop/lint/no_vcr_recording_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::NoVCRRecording do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it "registers an offense when using vcr: { record: ... }" do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/obscure_spec.rb
+++ b/spec/rubocop/cop/lint/obscure_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::Obscure do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it "registers an offense when using flipflop" do
     expect_offense(<<~RUBY)

--- a/spec/rubocop/cop/lint/use_positive_int32_validator_spec.rb
+++ b/spec/rubocop/cop/lint/use_positive_int32_validator_spec.rb
@@ -1,8 +1,9 @@
 # frozen_string_literal: true
 
 describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
-  let(:config) { RuboCop::Config.new }
   subject(:cop) { described_class.new(config) }
+
+  let(:config) { RuboCop::Config.new }
 
   it "handles a big params with nested params and such" do
     expect_offense(<<~RUBY)
@@ -30,7 +31,7 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
   end
 
   %w(requires optional).each do |method|
-    context 'registers an offense when not validating Integers in a Grape API `#{method}`' do
+    context "registers an offense when not validating Integers in a Grape API `#{method}`" do
       specify do
         expect_offense(<<~RUBY)
           params do
@@ -51,33 +52,33 @@ describe RuboCop::Cop::Lint::UsePositiveInt32Validator do
 
       it "handles multiple arguments" do
         expect_offense(<<~RUBY)
-        params do
-          #{method} :id, type: Integer, desc: 'Comment ID'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
-          requires :text, type: String
-        end
+          params do
+            #{method} :id, type: Integer, desc: 'Comment ID'
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+            requires :text, type: String
+          end
         RUBY
       end
 
       it "handles multiple arguments, in mixed order" do
         expect_offense(<<~RUBY)
-        params do
-          requires :text, type: String
-          #{method} :id, type: Integer, desc: 'Comment ID'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
-          requires :text, type: String
-          requires :id2, type: Integer, desc: 'Comment ID'
-                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
-        end
+          params do
+            requires :text, type: String
+            #{method} :id, type: Integer, desc: 'Comment ID'
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+            requires :text, type: String
+            requires :id2, type: Integer, desc: 'Comment ID'
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+          end
         RUBY
       end
 
       it "handles named params blocks" do
         expect_offense(<<~RUBY)
-        params :test do
-          #{method} :id, type: Integer, desc: 'Comment ID'
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
-        end
+          params :test do
+            #{method} :id, type: Integer, desc: 'Comment ID'
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Lint/UsePositiveInt32Validator: If this Integer maps to a postgres Integer column, validate with `positive_int32: true`
+          end
         RUBY
       end
     end


### PR DESCRIPTION
As the title suggests, it changes the configuration so that all cops are enabled by default, and we have to opt-out of the ones we don't want.

It will require some effort to detect which rules are the ones we didn't want to apply so that we explicitly turn them off.
