### PR TITLE
Update rubocop enabled and disabled rules 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.2.2
+      - image: cimg/ruby:3.2.3
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -32,7 +32,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.2.2
+      - image: cimg/ruby:3.2.3
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version:  "3.2.2"
+          ruby-version:  "3.2.3"
           bundler-cache: true
 
       - name: Setup pronto

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.1.0"
+    VERSION = "1.2.0"
   end
 end

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -8,3 +8,7 @@ Rails/HasManyOrHasOneDependent:
   Enabled: false
 Rails/TimeZone:
   Enabled: false
+Rails/ApplicationJob:
+  Enabled: false
+Rails/HttpPositionalArguments:
+  Enabled: false

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "rf/stylez/version"
 
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["emanuel@rainforestqa.com"]
   spec.license       = "MIT"
 
-  spec.summary       = %q{Styles for Rainforest code}
+  spec.summary       = "Styles for Rainforest code"
   spec.description   = "Configurations for Rubocop and other style enforcers/linters"
   spec.homepage      = "https://github.com/rainforestapp/rf-stylez"
 
@@ -20,12 +20,13 @@ Gem::Specification.new do |spec|
   spec.executables   = ["rf-stylez"]
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "rubocop", "1.59.0"
-  spec.add_runtime_dependency "rubocop-rails", "2.23.1"
-  spec.add_runtime_dependency "rubocop-rspec", "2.26.1"
-  spec.add_runtime_dependency "reek", "~> 6.2"
   spec.add_runtime_dependency "get_env", "~> 0.2.1"
-  spec.add_runtime_dependency "unparser", "~> 0.6"
   spec.add_runtime_dependency "pronto", "~> 0.11.2"
   spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.5"
+  spec.add_runtime_dependency "reek", "~> 6.3"
+  spec.add_runtime_dependency "rubocop", "1.63.2"
+  spec.add_runtime_dependency "rubocop-rails", "2.24.1"
+  spec.add_runtime_dependency "rubocop-rspec", "2.29.1"
+  spec.add_runtime_dependency "unparser", "~> 0.6"
+  spec.metadata["rubygems_mfa_required"] = "true"
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -44,7 +44,29 @@ Lint/NoVCRRecording:
 Layout/EmptyLineBetweenDefs:
   Enabled: true
   EmptyLineBetweenClassDefs: false
+Layout/LineLength:
+  Enabled: true
+  Max: 120
+  AllowHeredoc: true
+  AllowURI: true
+Layout/ArgumentAlignment:
+  Enabled: true
+  EnforcedStyle: with_fixed_indentation
+Layout/DotPosition:
+  Enabled: true
+  EnforcedStyle: leading
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
 
+RSpec/NotToNot:
+  Enabled: true
+  EnforcedStyle: to_not
+
+Style/Documentation:
+  Enabled: true
+  Exclude:
+    - 'db/migrate/*.rb'
 Style/FrozenStringLiteralComment:
   Enabled: true
   EnforcedStyle: always
@@ -70,12 +92,9 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   Enabled: true
   EnforcedStyleForMultiline: consistent_comma
-
-Layout/LineLength:
+Style/StringLiteralsInInterpolation:
   Enabled: true
-  Max: 120
-  AllowHeredoc: true
-  AllowURI: true
+  EnforcedStyle: double_quotes
 
 # Dumb lint cops
 Lint/AmbiguousOperator:
@@ -85,7 +104,21 @@ Lint/NonLocalExitFromIterator:
 Lint/AmbiguousRegexpLiteral:
   Enabled: false
 
+Metrics/ClassLength:
+  Enabled: false
 Metrics/MethodLength:
+  Enabled: false
+Metrics/AbcSize:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/ParameterLists:
   Enabled: false
 
 Naming/AccessorMethodName:
@@ -93,6 +126,10 @@ Naming/AccessorMethodName:
 Naming/PredicateName:
   Enabled: false
 Naming/HeredocDelimiterNaming:
+  Enabled: false
+Naming/RescuedExceptionsVariableName:
+  Enabled: false
+Naming/VariableNumber:
   Enabled: false
 
 RSpec/MultipleExpectations:
@@ -145,4 +182,6 @@ Style/FormatString:
 Style/FormatStringToken:
   Enabled: false
 Style/MapToHash:
+  Enabled: false
+Style/TrailingUnderscoreVariable:
   Enabled: false

--- a/spec/rf/stylez_spec.rb
+++ b/spec/rf/stylez_spec.rb
@@ -4,6 +4,6 @@ RSpec.describe Rf::Stylez do
   it "config should be valid" do
     expect do
       RuboCop::ConfigLoader.load_file("ruby/rubocop.yml")
-    end.not_to raise_error
+    end.to_not raise_error
   end
 end


### PR DESCRIPTION
* Copied the rules we were using on our main backend repository.
* Updated the dependency gems versions.
* Fixed some rubocop warnings.
* Releasing version 1.2.0