### PR TITLE
Revert some changes to fix push to rubygems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.2.3
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -32,7 +32,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.2.3
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version:  "3.2.3"
+          ruby-version:  "3.2.2"
           bundler-cache: true
 
       - name: Setup pronto

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.2.0"
+    VERSION = "1.1.1"
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["emanuel@rainforestqa.com"]
   spec.license       = "MIT"
 
-  spec.summary       = "Styles for Rainforest code"
+  spec.summary       = %q{Styles for Rainforest code}
   spec.description   = "Configurations for Rubocop and other style enforcers/linters"
   spec.homepage      = "https://github.com/rainforestapp/rf-stylez"
 
@@ -23,9 +23,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "get_env", "~> 0.2.1"
   spec.add_runtime_dependency "pronto", "~> 0.11.2"
   spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.5"
-  spec.add_runtime_dependency "reek", "~> 6.3"
-  spec.add_runtime_dependency "rubocop", "1.63.2"
-  spec.add_runtime_dependency "rubocop-rails", "2.24.1"
-  spec.add_runtime_dependency "rubocop-rspec", "2.29.1"
+  spec.add_runtime_dependency "reek", "~> 6.2"
+  spec.add_runtime_dependency "rubocop", "1.59.0"
+  spec.add_runtime_dependency "rubocop-rails", "2.23.1"
+  spec.add_runtime_dependency "rubocop-rspec", "2.26.1"
   spec.add_runtime_dependency "unparser", "~> 0.6"
 end


### PR DESCRIPTION
Not sure if reverting these things will actually fix the push to rubygems.

If it's still broken after this, then probably the problem is not the code, but in the integration with rubygems or the task we are using might be deprecated.