### PR TITLE
Attempt to fix push to rubygems

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.3.4
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -32,7 +32,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.3.4
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version:  "3.3.4"
+          ruby-version:  "3.2.2"
           bundler-cache: true
 
       - name: Setup pronto

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "bundler", "~> 2.5"
+gem "bundler", "~> 2.4"
 gem "byebug"
 gem "rake", "~> 13.1"
 gem "rspec", ">= 3.13"

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.2.0"
+    VERSION = "1.1.2"
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -20,13 +20,12 @@ Gem::Specification.new do |spec|
   spec.executables   = ["rf-stylez"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "get_env", "~> 0.2.1"
-  spec.add_dependency "pronto", "~> 0.11.2"
-  spec.add_dependency "pronto-rubocop", "~> 0.11.5"
-  spec.add_dependency "reek", "~> 6.2"
-  spec.add_dependency "rubocop", "1.65.1"
-  spec.add_dependency "rubocop-performance", "1.21.1"
-  spec.add_dependency "rubocop-rails", "2.25.1"
-  spec.add_dependency "rubocop-rspec", "3.0.4"
-  spec.add_dependency "unparser", "~> 0.6.15"
+  spec.add_runtime_dependency "get_env", "~> 0.2.1"
+  spec.add_runtime_dependency "pronto", "~> 0.11.2"
+  spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.5"
+  spec.add_runtime_dependency "reek", "~> 6.2"
+  spec.add_runtime_dependency "rubocop", "1.65.1"
+  spec.add_runtime_dependency "rubocop-rails", "2.25.1"
+  spec.add_runtime_dependency "rubocop-rspec", "2.31.0"
+  spec.add_runtime_dependency "unparser", "~> 0.6"
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.3
+  TargetRubyVersion: 3.2
   NewCops: enable
   SuggestExtensions: false
   Include:
@@ -20,7 +20,6 @@ inherit_from:
 require:
   - rf/stylez
   - rubocop-rspec
-  - rubocop-performance
   - get_env/cops
 
 # Custom cops


### PR DESCRIPTION
https://app.circleci.com/pipelines/github/rainforestapp/rf-stylez/321/workflows/c34d7194-7d35-4bf9-a4e2-523ca7b4a219/jobs/644

```
ERROR:  While executing gem ... (NoMethodError)
    undefined method `[]=' for nil

            stack[depth][key] = val
                        ^^^^^^^
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/yaml_serializer.rb:72:in `block in load'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/yaml_serializer.rb:58:in `split'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/yaml_serializer.rb:58:in `load'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/config_file.rb:545:in `load_with_rubygems_config_hash'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/config_file.rb:362:in `load_file'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/config_file.rb:297:in `load_api_keys'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/config_file.rb:243:in `api_keys'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/gemcutter_utilities.rb:51:in `api_key'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/gemcutter_utilities.rb:154:in `sign_in'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/commands/push_command.rb:65:in `execute'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/command.rb:326:in `invoke_with_build_args'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:255:in `invoke_command'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:194:in `process_args'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/command_manager.rb:152:in `run'
	/usr/local/lib/ruby/site_ruby/3.3.0/rubygems/gem_runner.rb:56:in `run'
	/usr/local/bin/gem:12:in `<main>'

Exited with code exit status 1

```