### PR TITLE
Update rubocop gems versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   test:
     docker:
-      - image: cimg/ruby:3.2.2
+      - image: cimg/ruby:3.3.6
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -12,7 +12,10 @@ jobs:
       - run:
           name: Install Ruby gems
           command: |
-            bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
+            gem install bundler
+            bundle config set --local path 'vendor/bundle'
+            bundle config set --local without pronto
+            bundle check || bundle install --jobs=`nproc` --retry=3
       - run:
           name: Set up test output directory
           command: sudo install -o circleci -d ~/rspec
@@ -32,7 +35,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.2.2
+      - image: cimg/ruby:3.3.6
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 100
       - run: git fetch --no-tags --prune --depth=100 origin "+refs/heads/$GITHUB_BASE_REF:refs/remotes/origin/$GITHUB_BASE_REF"
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version:  "3.2.2"
+          ruby-version:  "3.3.6"
           bundler-cache: true
 
       - name: Setup pronto

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,8 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "bundler", "~> 2.4"
+gem "bundler", "~> 2.5"
 gem "byebug"
-gem "rake", "~> 13.1"
+gem "rake", "~> 13.2"
 gem "rspec", ">= 3.13"
 gem "rspec_junit_formatter"

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.2.1"
+    VERSION = "1.2.2"
   end
 end

--- a/rf-stylez.gemspec
+++ b/rf-stylez.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "pronto", "~> 0.11.2"
   spec.add_runtime_dependency "pronto-rubocop", "~> 0.11.5"
   spec.add_runtime_dependency "reek", "~> 6.2"
-  spec.add_runtime_dependency "rubocop", "1.65.1"
-  spec.add_runtime_dependency "rubocop-performance", "1.21.1"
-  spec.add_runtime_dependency "rubocop-rails", "2.25.1"
-  spec.add_runtime_dependency "rubocop-rspec", "3.0.4"
+  spec.add_runtime_dependency "rubocop", "1.68.0"
+  spec.add_runtime_dependency "rubocop-performance", "1.23.0"
+  spec.add_runtime_dependency "rubocop-rails", "2.27.0"
+  spec.add_runtime_dependency "rubocop-rspec", "3.2.0"
   spec.add_runtime_dependency "unparser", "~> 0.6"
 end

--- a/ruby/rubocop.yml
+++ b/ruby/rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   NewCops: enable
   SuggestExtensions: false
   Include:


### PR DESCRIPTION
- Has been some time since we last updated them.
- Also set the repository Ruby version to the latest 3.3.6 and updated CircleCI and pronto scripts.