### PR TITLE
Fix push to rubygems by setting older Ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
 
   push_to_rubygems:
     docker:
-      - image: cimg/ruby:3.3.6
+      # Push to rubygems breaks with Ruby 3.3
+      - image: cimg/ruby:3.2.2
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.2.2"
+    VERSION = "1.2.3"
   end
 end


### PR DESCRIPTION
I've had this problem in the past, where I updated a few gem versions and also Ruby version, and then push to rubygems would fail, and never really understood what was the change breaking it.

Examples:
- https://github.com/rainforestapp/rf-stylez/pull/211
- https://github.com/rainforestapp/rf-stylez/pull/209
- https://github.com/rainforestapp/rf-stylez/pull/206

Now I think that it is probably due to setting Ruby 3.3 to the push_to_rubygems CircleCI job. So setting it to an older version as a workaround.
