### PR TITLE
Fix deprecation warning about inheriting from Cop instead of Base

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.2.4"
+    VERSION = "1.2.5"
   end
 end

--- a/lib/rubocop/cop/lint/no_bang_state_machine_events.rb
+++ b/lib/rubocop/cop/lint/no_bang_state_machine_events.rb
@@ -17,7 +17,7 @@ module RuboCop
       #       ...
       #     end
       #   end
-      class NoBangStateMachineEvents < Cop
+      class NoBangStateMachineEvents < Base
         MSG = "Event names ending with a `!` define `!`-ended methods that do not raise"
 
         def_node_matcher :is_state_machine_event?, "(send nil? :event (sym $_))"

--- a/lib/rubocop/cop/lint/no_grape_api.rb
+++ b/lib/rubocop/cop/lint/no_grape_api.rb
@@ -12,7 +12,7 @@ module RuboCop
       #
       #   # good
       #   class Foo < Api::Base
-      class NoGrapeAPI < Cop
+      class NoGrapeAPI < Base
         MSG = "Prefer inheriting `Api::AuthBase` or `Api::Base` instead of `Grape::API`."
 
         def_node_matcher :inherits_Grape_API?, "(class (const ...) (const (const nil? :Grape) :API) ...)"

--- a/lib/rubocop/cop/lint/no_http_party.rb
+++ b/lib/rubocop/cop/lint/no_http_party.rb
@@ -9,7 +9,7 @@ module RuboCop
       #
       #   # good
       #   TimedRequest.get(...)
-      class NoHTTParty < Cop
+      class NoHTTParty < Base
         MSG = "Prefer `TimedRequest` instead of raw `HTTParty` calls."
 
         def_node_matcher :is_HTTParty?, "(send (const nil? :HTTParty) ...)"

--- a/lib/rubocop/cop/lint/no_json.rb
+++ b/lib/rubocop/cop/lint/no_json.rb
@@ -10,7 +10,7 @@ module RuboCop
       #   # good
       #   MultiJson.load(...)
       #
-      class NoJSON < Cop
+      class NoJSON < Base
         MSG = "Use `MultiJson` instead of `JSON`."
 
         def_node_matcher :is_JSON?, "(const nil? :JSON)"

--- a/lib/rubocop/cop/lint/no_untyped_raise.rb
+++ b/lib/rubocop/cop/lint/no_untyped_raise.rb
@@ -10,7 +10,7 @@ module RuboCop
       #   # good
       #   raise ArgumentError, 'foo'
       #
-      class NoUntypedRaise < Cop
+      class NoUntypedRaise < Base
         MSG = "Do not raise untyped exceptions, specify the error type so it can be rescued specifically."
 
         def_node_matcher :is_untyped_raise?, "(send nil? {:raise :fail} (str ...) ...)"

--- a/lib/rubocop/cop/lint/obscure.rb
+++ b/lib/rubocop/cop/lint/obscure.rb
@@ -19,7 +19,7 @@ module RuboCop
       #   "%s" % "string"
       #
       # https://ruby-doc.org/core-2.4.0/String.html#method-i-25
-      class Obscure < Cop
+      class Obscure < Base
         MSG = "Do not use the flipflop operator"
 
         def_node_matcher :is_stringformat?, <<-PATTERN

--- a/lib/rubocop/cop/lint/use_positive_int32_validator.rb
+++ b/lib/rubocop/cop/lint/use_positive_int32_validator.rb
@@ -13,7 +13,7 @@ module RuboCop
       #   params do
       #     requires :id, type: Integer, positive_int32: true
       #   end
-      class UsePositiveInt32Validator < Cop
+      class UsePositiveInt32Validator < Base
         MSG = "If this Integer maps to a postgres Integer column, validate with `positive_int32: true`"
 
         # check if the param is `requires` / `optional`


### PR DESCRIPTION
Example deprecation warning:
```
rf-stylez/lib/rubocop/cop/lint/no_grape_api.rb:15: warning: Inheriting from `RuboCop::Cop::Cop` is deprecated. Use `RuboCop::Cop::Base` instead.
For more information, see https://docs.rubocop.org/rubocop/v1_upgrade_notes.html.
```

This PR fixes those