### PR TITLE
Fix pushing to rubygems with newer rubies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,8 +35,7 @@ jobs:
 
   push_to_rubygems:
     docker:
-      # Push to rubygems breaks with Ruby 3.3
-      - image: cimg/ruby:3.2.2
+      - image: cimg/ruby:3.3.6
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -47,7 +46,7 @@ jobs:
           command: |
             mkdir ~/.gem
             echo "---
-              :rubygems_api_key: $RUBYGEMS_API_KEY
+            :rubygems_api_key: $RUBYGEMS_API_KEY
             " > ~/.gem/credentials
             chmod 600 ~/.gem/credentials
       - run:


### PR DESCRIPTION
Newer ruby is more strict when parsing the credentials yaml file, and the leading spaces we had in it are not good/valid yaml.

I tested this fix in the get_env repo here:
https://github.com/rainforestapp/get_env/pull/122