### PR TITLE
Prevent the use of `Time.now` and `Time.parse`

### DIFF
--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -6,8 +6,6 @@ Rails/ActionOrder:
   Enabled: false
 Rails/HasManyOrHasOneDependent:
   Enabled: false
-Rails/TimeZone:
-  Enabled: false
 Rails/ApplicationJob:
   Enabled: false
 Rails/HttpPositionalArguments:


### PR DESCRIPTION
I have no idea why we had that cop disabled but it's long been established best practice to use `Time.current` or `Time.zone...` in Rails apps to ensure that everything works regardless of the system time zone. See: https://thoughtbot.com/blog/its-about-time-zones

I recently ran into a bunch of these issues when trying to make the specs in the main app pass locally so I guess now I know how those calls made it in there.

https://www.rubydoc.info/gems/rubocop/0.57.2/RuboCop/Cop/Rails/TimeZone