### PR TITLE
Fix warning by replacing require with plugins

### DIFF
--- a/lib/rf/stylez/version.rb
+++ b/lib/rf/stylez/version.rb
@@ -2,6 +2,6 @@
 
 module Rf
   module Stylez
-    VERSION = "1.2.6"
+    VERSION = "1.2.7"
   end
 end

--- a/rails/rubocop.yml
+++ b/rails/rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-rails
+plugins:
+  - rubocop-rails
 
 Rails/I18nLocaleTexts:
   Enabled: false


### PR DESCRIPTION
Warning said:
```
rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /gems/rf-stylez-1.2.6/rails/rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```